### PR TITLE
Argument 1 must be of the type integer, string given

### DIFF
--- a/src/Console/Command/StartCallbackConsumerCommand.php
+++ b/src/Console/Command/StartCallbackConsumerCommand.php
@@ -82,6 +82,6 @@ class StartCallbackConsumerCommand extends AbstractCommand
         $callbackConsumer = $container->get($consumerName);
         /* @var Consumer $callbackConsumer */
 
-        $callbackConsumer->consume($input->getOption('amount'));
+        $callbackConsumer->consume((int) $input->getOption('amount'));
     }
 }


### PR DESCRIPTION
Amount is a string coming from the CLI. Must be casted due to type hinting 

Fatal error: Uncaught TypeError: Argument 1 passed to Humus\Amqp\AbstractConsumer::consume() must be of the type integer, string given, called in

```
php ./bin/humus-amqp.php consumer --name command-consumer --amount 100
```