### PR TITLE
Allowed different service names for exchanges

### DIFF
--- a/src/Container/QueueFactory.php
+++ b/src/Container/QueueFactory.php
@@ -25,6 +25,7 @@ namespace Humus\Amqp\Container;
 use Humus\Amqp\Channel;
 use Humus\Amqp\Constants;
 use Humus\Amqp\Exception;
+use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
 use Interop\Config\ConfigurationTrait;
 use Interop\Config\ProvidesDefaultOptions;
@@ -156,20 +157,24 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
                 throw new Exception\InvalidArgumentException('Expected an array or traversable of exchanges');
             }
 
+            /** @var Exchange[] $exchangeObjects */
+            $exchangeObjects = [];
             foreach ($exchanges as $exchange => $exchangeOptions) {
-                ExchangeFactory::$exchange($container, $this->channel, true);
+                $exchangeObjects[$exchange] = ExchangeFactory::$exchange($container, $this->channel, true);
             }
 
             $queue->declareQueue();
 
             foreach ($exchanges as $exchange => $exchangeOptions) {
+                $exchangeObject = $exchangeObjects[$exchange];
+                $exchangeName = $exchangeObject->getName();
                 if (empty($exchangeOptions)) {
-                    $this->bindQueue($queue, $exchange, [], []);
+                    $this->bindQueue($queue, $exchangeName, [], []);
                 } else {
                     foreach ($exchangeOptions as $exchangeOption) {
                         $routingKeys = $exchangeOption['routing_keys'] ?? [];
                         $bindArguments = $exchangeOption['bind_arguments'] ?? [];
-                        $this->bindQueue($queue, $exchange, $routingKeys, $bindArguments);
+                        $this->bindQueue($queue, $exchangeName, $routingKeys, $bindArguments);
                     }
                 }
             }

--- a/tests/Console/Command/SetupFabricCommandTest.php
+++ b/tests/Console/Command/SetupFabricCommandTest.php
@@ -97,6 +97,7 @@ class SetupFabricCommandTest extends TestCase
         $exchange->setType('direct')->shouldBeCalled();
         $exchange->setArguments([])->shouldBeCalled();
         $exchange->declareExchange()->shouldBeCalled();
+        $exchange->getName()->willReturn('demo');
 
         $queue = $this->prophesize(Queue::class);
         $queue->setName('foo')->shouldBeCalled();

--- a/tests/Container/QueueFactoryTest.php
+++ b/tests/Container/QueueFactoryTest.php
@@ -30,6 +30,7 @@ use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
 use Interop\Container\ContainerInterface;
 use PHPUnit_Framework_TestCase as TestCase;
+use Prophecy\Argument;
 
 /**
  * Class QueueFactoryTest
@@ -232,6 +233,12 @@ class QueueFactoryTest extends TestCase
         ])->shouldBeCalled();
 
         $exchange = $this->prophesize(Exchange::class);
+        $exchange->setName(Argument::any())->shouldBeCalled();
+        $exchange->setFlags(Argument::any())->shouldBeCalled();
+        $exchange->setType(Argument::any())->shouldBeCalled();
+        $exchange->setArguments(Argument::any())->shouldBeCalled();
+        $exchange->getName()->willReturn('my_exchange');
+        $exchange->declareExchange()->shouldBeCalled();
 
         $queue = $this->prophesize(Queue::class);
         $queue->setName('my_queue')->shouldBeCalled();
@@ -292,6 +299,12 @@ class QueueFactoryTest extends TestCase
         ])->shouldBeCalled();
 
         $exchange = $this->prophesize(Exchange::class);
+        $exchange->setName(Argument::any())->shouldBeCalled();
+        $exchange->setFlags(Argument::any())->shouldBeCalled();
+        $exchange->setType(Argument::any())->shouldBeCalled();
+        $exchange->setArguments(Argument::any())->shouldBeCalled();
+        $exchange->getName()->willReturn('my_exchange');
+        $exchange->declareExchange()->shouldBeCalled();
 
         $queue = $this->prophesize(Queue::class);
         $queue->setName('my_queue')->shouldBeCalled();
@@ -418,6 +431,12 @@ class QueueFactoryTest extends TestCase
         ])->shouldBeCalled();
 
         $exchange = $this->prophesize(Exchange::class);
+        $exchange->setName(Argument::any())->shouldBeCalled();
+        $exchange->setFlags(Argument::any())->shouldBeCalled();
+        $exchange->setType(Argument::any())->shouldBeCalled();
+        $exchange->setArguments(Argument::any())->shouldBeCalled();
+        $exchange->getName()->willReturn('my_exchange');
+        $exchange->declareExchange()->shouldBeCalled();
 
         $queue = $this->prophesize(Queue::class);
         $queue->setName('my_queue')->shouldBeCalled();
@@ -497,6 +516,7 @@ class QueueFactoryTest extends TestCase
         $exchange->setFlags(2)->shouldBeCalled();
         $exchange->setArguments([])->shouldBeCalled();
         $exchange->declareExchange()->shouldBeCalled();
+        $exchange->getName()->willReturn('my_exchange');
 
         $queue = $this->prophesize(Queue::class);
         $queue->setName('my_queue')->shouldBeCalled();


### PR DESCRIPTION
This PR allows to bind queues with the defined exchange `name` property, not with the exchange key in configuration.

Actually you can define exchanges in configuration like this (note different configuration key and `name`):

``` php
return [
    'humus' => [
        'amqp' => [
            'exchange' => [
                'my-exchange-key' => [
                    'connection' => 'amqp.connection.default',
                    'name' => 'my-exchange',
                    'type' => 'fanout',
                ],
            ],
        ],
    ],
];
```

But you can't define a queue like this:

``` php
return [
    'humus' => [
        'amqp' => [
            'queue' => [
                'my-queue' => [
                    'connection' => 'amqp.connection.default',
                    'name' => 'my-queue',
                    'exchanges' => [
                        'my-exchange-key' => [],
                    ],
                ],
            ],
        ],
    ],
];
```

The queue factory looks for the exchange via configuration key and binds it with this key, not with the real exchange name.

This PR fix this problem.
