### PR TITLE
adds exchange name as array key in rpc client factory

### DIFF
--- a/src/Container/JsonRpcClientFactory.php
+++ b/src/Container/JsonRpcClientFactory.php
@@ -108,7 +108,7 @@ final class JsonRpcClientFactory implements ProvidesDefaultOptions, RequiresConf
         $exchanges = [];
 
         foreach ($options['exchanges'] as $exchange) {
-            $exchanges[] = ExchangeFactory::$exchange($container, $channel);
+            $exchanges[$exchange] = ExchangeFactory::$exchange($container, $channel);
         }
 
         return new JsonRpcClient($queue, $exchanges, $options['wait_micros'], $options['app_id']);


### PR DESCRIPTION
In `JsonRpcRequest` the first constructor argument is used to define the exchange to be used for publishing. This string is than used in `JsonRpcClient` to find the configured exchange in an array. But the `RpcClientFactory` only uses increasing integers as array keys.

This PR changes this behavior by adding the exchange name as array key.