### PR TITLE
Added ability to change strategy of rejection a message

### DIFF
--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -23,6 +23,7 @@ declare(strict_types=1);
 namespace Humus\Amqp;
 
 use Assert\Assertion;
+use Humus\Amqp\Exception\RuntimeException;
 use Psr\Log\LoggerInterface;
 
 /**
@@ -243,12 +244,10 @@ abstract class AbstractConsumer implements Consumer
         }
 
         if (! is_bool($requeue)) {
-            $this->logger->error(sprintf(
+            throw new RuntimeException(sprintf(
                 'The error callback must returns boolean or null, given "%s".',
                 is_object($requeue) ? get_class($requeue) : gettype($requeue)
             ));
-
-            return true;
         }
 
         return $requeue;


### PR DESCRIPTION
Ref #49 

**BC break.** Now, `flushDeferred` returns `FlushDeferredResult::MSG_REJECT_REQUEUE()` by default, when thrown an exception during flush deferred messages. If this change is critical, we can exctract a piece of logic out of `handleException`.