### PR TITLE
removes recursive auto setup flag from exchange and queue factory

### DIFF
--- a/src/Container/ExchangeFactory.php
+++ b/src/Container/ExchangeFactory.php
@@ -139,14 +139,14 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
             if (isset($options['arguments']['alternate-exchange'])) {
                 // auto setup fabric alternate exchange
                 $exchangeName = $options['arguments']['alternate-exchange'];
-                ExchangeFactory::$exchangeName($container, $this->channel, true);
+                ExchangeFactory::$exchangeName($container, $this->channel);
             }
 
             $exchange->declareExchange();
 
             // rabbitmq extension: exchange to exchange bindings
             foreach ($options['exchange_bindings'] as $exchangeName => $bindOptions) {
-                ExchangeFactory::$exchangeName($container, $this->channel, true);
+                ExchangeFactory::$exchangeName($container, $this->channel);
                 if (empty($bindOptions)) {
                     $this->bindExchange($exchange, $exchangeName, [], []);
                 } else {

--- a/src/Container/QueueFactory.php
+++ b/src/Container/QueueFactory.php
@@ -144,7 +144,7 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
             if (isset($options['arguments']['x-dead-letter-exchange'])) {
                 // auto setup fabric dead letter exchange
                 $exchangeName = $options['arguments']['x-dead-letter-exchange'];
-                ExchangeFactory::$exchangeName($container, $this->channel, true);
+                ExchangeFactory::$exchangeName($container, $this->channel);
             }
 
             $exchanges = $options['exchanges'];
@@ -160,7 +160,7 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
             /** @var Exchange[] $exchangeObjects */
             $exchangeObjects = [];
             foreach ($exchanges as $exchange => $exchangeOptions) {
-                $exchangeObjects[$exchange] = ExchangeFactory::$exchange($container, $this->channel, true);
+                $exchangeObjects[$exchange] = ExchangeFactory::$exchange($container, $this->channel);
             }
 
             $queue->declareQueue();

--- a/tests/Container/ExchangeFactoryTest.php
+++ b/tests/Container/ExchangeFactoryTest.php
@@ -254,7 +254,7 @@ class ExchangeFactoryTest extends TestCase
                         'base_exchange_one' => [
                             'connection' => 'my_connection',
                             'name' => 'base_exchange_one',
-                            'auto_setup_fabric' => false,
+                            'auto_setup_fabric' => true,
                         ],
                         'my_exchange' => [
                             'connection' => 'my_connection',
@@ -297,6 +297,7 @@ class ExchangeFactoryTest extends TestCase
                         'base_exchange_three' => [
                             'connection' => 'my_connection',
                             'name' => 'base_exchange_three',
+                            'auto_setup_fabric' => true,
                         ],
                     ],
                 ],
@@ -372,7 +373,7 @@ class ExchangeFactoryTest extends TestCase
                         'alternate-exchange' => [
                             'connection' => 'my_connection',
                             'name' => 'alternate-exchange',
-                            'auto_setup_fabric' => false,
+                            'auto_setup_fabric' => true,
                         ],
                         'my_exchange' => [
                             'connection' => 'my_connection',

--- a/tests/Container/QueueFactoryTest.php
+++ b/tests/Container/QueueFactoryTest.php
@@ -480,10 +480,12 @@ class QueueFactoryTest extends TestCase
                         'error_exchange' => [
                             'connection' => 'my_connection',
                             'name' => 'error_exchange',
+                            'auto_setup_fabric' => true,
                         ],
                         'my_exchange' => [
                             'connection' => 'my_connection',
                             'name' => 'my_exchange',
+                            'auto_setup_fabric' => true,
                         ],
                     ],
                     'queue' => [


### PR DESCRIPTION
This PR removes the `$autoSetupFabric` from inner calls in `ExchangeFactory` and `QueueFactory`.
Since some users could depending on this auto setup, this could be a bc break.

My proposal is it to remove that flag from `ExchangeFactory` at all and use instead only the `auto_setup_fabric` from exchange config.

Another approach could be to add a "do not auto setup binded exchanges" config parameter. But yes, this would be strange.

It is not always possible to know the whole config for exchanges. So this call would throw an exception if the provided exchange config does not match exchanges already exists on the rabbit broker.

So it should be possible to only bind a queue to an existing exchange with only know his name (not his whole configuration). Also a dead letter binding to an existing exchange should work.