### PR TITLE
cancel queue request on signal to prevent streams from blocking

### DIFF
--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -172,7 +172,6 @@ abstract class AbstractConsumer implements Consumer
 
             if (! $this->keepAlive || (0 !== $this->target && $this->countMessagesConsumed >= $this->target)) {
                 $this->ackOrNackBlock();
-                $this->queue->cancel($this->consumerTag);
                 $this->shutdown();
 
                 return false;
@@ -221,6 +220,7 @@ abstract class AbstractConsumer implements Consumer
     public function shutdown()
     {
         $this->keepAlive = false;
+        $this->queue->cancel($this->consumerTag);
     }
 
     /**

--- a/src/Driver/PhpAmqpLib/Queue.php
+++ b/src/Driver/PhpAmqpLib/Queue.php
@@ -304,7 +304,7 @@ final class Queue implements QueueInterface
         $this->channel->getResource()->basic_cancel(
             $consumerTag,
             (bool) ($this->flags & Constants::AMQP_NOWAIT),
-            false
+            true
         );
     }
 


### PR DESCRIPTION
The amqp extension + library has its own mechanism to remove blocking for requests, if the signal handler is activated. 

But the cancelation for requests was not called from this library, so i have moved some code around to get rid of that issue: closes #45 

I am not sure about side effects, so please have an extra review round. ;)