### PR TITLE
json rpc server returns trace if enabled

### DIFF
--- a/src/JsonRpc/Error.php
+++ b/src/JsonRpc/Error.php
@@ -37,9 +37,4 @@ interface Error
      * @return string
      */
     public function message();
-
-    /**
-     * @return string|null
-     */
-    public function traceAsString();
 }

--- a/src/JsonRpc/Error.php
+++ b/src/JsonRpc/Error.php
@@ -37,4 +37,12 @@ interface Error
      * @return string
      */
     public function message();
+
+    /**
+     * @return array|bool|float|int|null|string
+     *
+     * see: https://github.com/prolic/HumusAmqp/issues/64
+     * will be added to interface with 2.0
+     */
+    //public function data();
 }

--- a/src/JsonRpc/Error.php
+++ b/src/JsonRpc/Error.php
@@ -37,4 +37,9 @@ interface Error
      * @return string
      */
     public function message();
+
+    /**
+     * @return string|null
+     */
+    public function traceAsString();
 }

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -238,7 +238,7 @@ final class JsonRpcClient implements Client
         } else {
             $response = JsonRpcResponse::withError(
                 $envelope->getCorrelationId(),
-                new JsonRpcError($payload['error']['code'], $payload['error']['message']),
+                new JsonRpcError($payload['error']['code'], $payload['error']['message'], $payload['error']['trace_as_string']),
                 $payload['data'] ?? null
             );
         }

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -238,7 +238,7 @@ final class JsonRpcClient implements Client
         } else {
             $response = JsonRpcResponse::withError(
                 $envelope->getCorrelationId(),
-                new JsonRpcError($payload['error']['code'], $payload['error']['message']),
+                new JsonRpcError($payload['error']['code'], $payload['error']['message'], $payload['data'] ?? null),
                 $payload['data'] ?? null
             );
         }

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -238,7 +238,7 @@ final class JsonRpcClient implements Client
         } else {
             $response = JsonRpcResponse::withError(
                 $envelope->getCorrelationId(),
-                new JsonRpcError($payload['error']['code'], $payload['error']['message'], $payload['error']['trace_as_string']),
+                new JsonRpcError($payload['error']['code'], $payload['error']['message']),
                 $payload['data'] ?? null
             );
         }

--- a/src/JsonRpc/JsonRpcError.php
+++ b/src/JsonRpc/JsonRpcError.php
@@ -62,12 +62,17 @@ final class JsonRpcError implements Error
     private $message;
 
     /**
+     * @var array|bool|float|int|null|string
+     */
+    private $data;
+
+    /**
      * JsonRpcError constructor.
      * @param int $code
      * @param string|null $message
      * @param string|null $traceAsString
      */
-    public function __construct(int $code, string $message = null)
+    public function __construct(int $code, string $message = null, $data = null)
     {
         if (! defined(JsonRpcError::class . '::ERROR_CODE_' . -$code)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -82,6 +87,7 @@ final class JsonRpcError implements Error
 
         $this->code = $code;
         $this->message = $message;
+        $this->data = $data;
     }
 
     /**
@@ -98,5 +104,16 @@ final class JsonRpcError implements Error
     public function message()
     {
         return $this->message;
+    }
+
+    /**
+     * @return array|bool|float|int|null|string
+     *
+     * see: https://github.com/prolic/HumusAmqp/issues/64
+     * will be added to interface with 2.0
+     */
+    public function data()
+    {
+        return $this->data;
     }
 }

--- a/src/JsonRpc/JsonRpcError.php
+++ b/src/JsonRpc/JsonRpcError.php
@@ -62,17 +62,12 @@ final class JsonRpcError implements Error
     private $message;
 
     /**
-     * @var null|string
-     */
-    private $traceAsString;
-
-    /**
      * JsonRpcError constructor.
      * @param int $code
      * @param string|null $message
      * @param string|null $traceAsString
      */
-    public function __construct(int $code, string $message = null, string $traceAsString = null)
+    public function __construct(int $code, string $message = null)
     {
         if (! defined(JsonRpcError::class . '::ERROR_CODE_' . -$code)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -87,7 +82,6 @@ final class JsonRpcError implements Error
 
         $this->code = $code;
         $this->message = $message;
-        $this->traceAsString = $traceAsString;
     }
 
     /**
@@ -104,13 +98,5 @@ final class JsonRpcError implements Error
     public function message()
     {
         return $this->message;
-    }
-
-    /**
-     * @return null|string
-     */
-    public function traceAsString()
-    {
-        return $this->traceAsString;
     }
 }

--- a/src/JsonRpc/JsonRpcError.php
+++ b/src/JsonRpc/JsonRpcError.php
@@ -62,11 +62,17 @@ final class JsonRpcError implements Error
     private $message;
 
     /**
+     * @var null|string
+     */
+    private $traceAsString;
+
+    /**
      * JsonRpcError constructor.
      * @param int $code
      * @param string|null $message
+     * @param string|null $traceAsString
      */
-    public function __construct(int $code, string $message = null)
+    public function __construct(int $code, string $message = null, string $traceAsString = null)
     {
         if (! defined(JsonRpcError::class . '::ERROR_CODE_' . -$code)) {
             throw new Exception\InvalidArgumentException(sprintf(
@@ -81,6 +87,7 @@ final class JsonRpcError implements Error
 
         $this->code = $code;
         $this->message = $message;
+        $this->traceAsString = $traceAsString;
     }
 
     /**
@@ -97,5 +104,13 @@ final class JsonRpcError implements Error
     public function message()
     {
         return $this->message;
+    }
+
+    /**
+     * @return null|string
+     */
+    public function traceAsString()
+    {
+        return $this->traceAsString;
     }
 }

--- a/src/JsonRpc/JsonRpcResponse.php
+++ b/src/JsonRpc/JsonRpcResponse.php
@@ -126,6 +126,7 @@ final class JsonRpcResponse implements Response
 
     /**
      * @return array|bool|float|int|null|string
+     * @deprecated will be moved to Error in 2.0
      */
     public function data()
     {

--- a/src/JsonRpc/JsonRpcServer.php
+++ b/src/JsonRpc/JsonRpcServer.php
@@ -139,7 +139,8 @@ final class JsonRpcServer extends AbstractConsumer
                     JsonRpcError::ERROR_CODE_32600,
                     null,
                     $this->returnTrace ? $e->getTraceAsString() : null
-                )
+                ),
+                $this->returnTrace ? $e->getTraceAsString() : null
             );
         } catch (Exception\InvalidJsonRpcRequest $e) {
             $this->logger->error('Invalid json rpc request', $this->extractMessageInformation($envelope));
@@ -149,7 +150,8 @@ final class JsonRpcServer extends AbstractConsumer
                     JsonRpcError::ERROR_CODE_32600,
                     null,
                     $this->returnTrace ? $e->getTraceAsString() : null
-                )
+                ),
+                $this->returnTrace ? $e->getTraceAsString() : null
             );
         } catch (Exception\JsonParseError $e) {
             $this->logger->error('Json parse error', $this->extractMessageInformation($envelope));
@@ -159,7 +161,8 @@ final class JsonRpcServer extends AbstractConsumer
                     JsonRpcError::ERROR_CODE_32700,
                     null,
                     $this->returnTrace ? $e->getTraceAsString() : null
-                )
+                ),
+                $this->returnTrace ? $e->getTraceAsString() : null
             );
         } catch (\Throwable $e) {
             $extra = $this->extractMessageInformation($envelope);
@@ -171,7 +174,8 @@ final class JsonRpcServer extends AbstractConsumer
                 $envelope->getCorrelationId(),
                 new JsonRpcError(
                     JsonRpcError::ERROR_CODE_32603,
-                    null
+                    null,
+                    $this->returnTrace ? $e->getTraceAsString() : null
                 ),
                 $this->returnTrace ? $e->getTraceAsString() : null
             );

--- a/src/JsonRpc/JsonRpcServer.php
+++ b/src/JsonRpc/JsonRpcServer.php
@@ -171,9 +171,9 @@ final class JsonRpcServer extends AbstractConsumer
                 $envelope->getCorrelationId(),
                 new JsonRpcError(
                     JsonRpcError::ERROR_CODE_32603,
-                    null,
-                    $this->returnTrace ? $e->getTraceAsString() : null
-                )
+                    null
+                ),
+                $this->returnTrace ? $e->getTraceAsString() : null
             );
         }
 
@@ -206,7 +206,6 @@ final class JsonRpcServer extends AbstractConsumer
                 'error' => [
                     'code' => $response->error()->code(),
                     'message' => $response->error()->message(),
-                    'trace_as_string' => $this->returnTrace ? $response->error()->traceAsString() : null,
                 ],
                 'data' => $response->data(),
             ];
@@ -223,7 +222,6 @@ final class JsonRpcServer extends AbstractConsumer
                 'error' => [
                     'code' => JsonRpcError::ERROR_CODE_32603,
                     'message' => 'Internal error',
-                    'trace_as_string' => null,
                 ],
             ]);
         }

--- a/src/JsonRpc/JsonRpcServer.php
+++ b/src/JsonRpc/JsonRpcServer.php
@@ -223,6 +223,7 @@ final class JsonRpcServer extends AbstractConsumer
                 'error' => [
                     'code' => JsonRpcError::ERROR_CODE_32603,
                     'message' => 'Internal error',
+                    'trace_as_string' => null,
                 ],
             ]);
         }

--- a/src/JsonRpc/JsonRpcServer.php
+++ b/src/JsonRpc/JsonRpcServer.php
@@ -48,6 +48,11 @@ final class JsonRpcServer extends AbstractConsumer
     private $appId;
 
     /**
+     * @var bool
+     */
+    private $returnTrace;
+
+    /**
      * Constructor
      *
      * @param Queue $queue
@@ -56,6 +61,7 @@ final class JsonRpcServer extends AbstractConsumer
      * @param float $idleTimeout in seconds
      * @param string $consumerTag
      * @param string $appId
+     * @praram bool $returnTrace
      */
     public function __construct(
         Queue $queue,
@@ -63,7 +69,8 @@ final class JsonRpcServer extends AbstractConsumer
         LoggerInterface $logger,
         float $idleTimeout,
         string $consumerTag = '',
-        string $appId = ''
+        string $appId = '',
+        bool $returnTrace = false
     ) {
         if ('' === $consumerTag) {
             $consumerTag = bin2hex(random_bytes(24));
@@ -87,6 +94,7 @@ final class JsonRpcServer extends AbstractConsumer
         $this->idleTimeout = $idleTimeout;
         $this->consumerTag = $consumerTag;
         $this->appId = $appId;
+        $this->returnTrace = $returnTrace;
     }
 
     /**
@@ -125,20 +133,48 @@ final class JsonRpcServer extends AbstractConsumer
             }
         } catch (Exception\InvalidJsonRpcVersion $e) {
             $this->logger->error('Invalid json rpc version', $this->extractMessageInformation($envelope));
-            $response = JsonRpcResponse::withError($envelope->getCorrelationId(), new JsonRpcError(JsonRpcError::ERROR_CODE_32600));
+            $response = JsonRpcResponse::withError(
+                $envelope->getCorrelationId(),
+                new JsonRpcError(
+                    JsonRpcError::ERROR_CODE_32600,
+                    null,
+                    $this->returnTrace ? $e->getTraceAsString() : null
+                )
+            );
         } catch (Exception\InvalidJsonRpcRequest $e) {
             $this->logger->error('Invalid json rpc request', $this->extractMessageInformation($envelope));
-            $response = JsonRpcResponse::withError($envelope->getCorrelationId(), new JsonRpcError(JsonRpcError::ERROR_CODE_32600));
+            $response = JsonRpcResponse::withError(
+                $envelope->getCorrelationId(),
+                new JsonRpcError(
+                    JsonRpcError::ERROR_CODE_32600,
+                    null,
+                    $this->returnTrace ? $e->getTraceAsString() : null
+                )
+            );
         } catch (Exception\JsonParseError $e) {
             $this->logger->error('Json parse error', $this->extractMessageInformation($envelope));
-            $response = JsonRpcResponse::withError($envelope->getCorrelationId(), new JsonRpcError(JsonRpcError::ERROR_CODE_32700));
+            $response = JsonRpcResponse::withError(
+                $envelope->getCorrelationId(),
+                new JsonRpcError(
+                    JsonRpcError::ERROR_CODE_32700,
+                    null,
+                    $this->returnTrace ? $e->getTraceAsString() : null
+                )
+            );
         } catch (\Throwable $e) {
             $extra = $this->extractMessageInformation($envelope);
             $extra['exception_class'] = get_class($e);
             $extra['exception_message'] = $e->getMessage();
             $extra['exception_trace'] = $e->getTraceAsString();
             $this->logger->error('Exception occurred', $extra);
-            $response = JsonRpcResponse::withError($envelope->getCorrelationId(), new JsonRpcError(JsonRpcError::ERROR_CODE_32603));
+            $response = JsonRpcResponse::withError(
+                $envelope->getCorrelationId(),
+                new JsonRpcError(
+                    JsonRpcError::ERROR_CODE_32603,
+                    null,
+                    $this->returnTrace ? $e->getTraceAsString() : null
+                )
+            );
         }
 
         $this->sendReply($response, $envelope);
@@ -170,6 +206,7 @@ final class JsonRpcServer extends AbstractConsumer
                 'error' => [
                     'code' => $response->error()->code(),
                     'message' => $response->error()->message(),
+                    'trace_as_string' => $this->returnTrace ? $response->error()->traceAsString() : null,
                 ],
                 'data' => $response->data(),
             ];

--- a/src/JsonRpc/Response.php
+++ b/src/JsonRpc/Response.php
@@ -50,6 +50,7 @@ interface Response
 
     /**
      * @return array|bool|float|int|null|string
+     * @deprecated will be moved to Error in 2.0
      */
     public function data();
 }

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -792,7 +792,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
         $response1 = $responses->getResponse('request-1');
         $this->assertTrue($response1->isError());
-        $this->assertTrue(is_string($response1->error()->traceAsString()));
-        $this->assertNotEmpty($response1->error()->traceAsString());
+        $this->assertInternalType('string', $response1->data());
+        $this->assertNotEmpty($response1->data());
     }
 }

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -794,5 +794,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $this->assertTrue($response1->isError());
         $this->assertInternalType('string', $response1->data());
         $this->assertNotEmpty($response1->data());
+        $this->assertInternalType('string', $response1->error()->data());
+        $this->assertNotEmpty($response1->error()->data());
     }
 }

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -736,7 +736,6 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
     /**
      * @test
-     * @group by
      */
     public function it_returns_trace_when_enabled()
     {


### PR DESCRIPTION
see also: https://github.com/prolic/HumusAmqp/pull/56

This is a small BC as the Error Interface now has an additional method. Usually it would not be expected to have an implementation of this Error Interface in userland code, so maybe we can introduce it without new major version.

Thoughts? @oqq @thomasvargiu @bweston92 