### PR TITLE
adds a test for empty json rpc response collections

### DIFF
--- a/tests/JsonRpc/ResponseCollectionTest.php
+++ b/tests/JsonRpc/ResponseCollectionTest.php
@@ -58,4 +58,20 @@ class ResponseCollectionTest extends TestCase
 
         $this->assertNull($responseCollection->getResponse('unknown id'));
     }
+
+    /**
+     * @test
+     */
+    public function it_iterates_and_accesses_correctly_without_results()
+    {
+        $responseCollection = new JsonRpcResponseCollection();
+
+        $this->assertCount(0, $responseCollection);
+        $this->assertFalse($responseCollection->hasResponse('unknown id'));
+        $this->assertNull($responseCollection->getResponse('unknown id'));
+
+        foreach ($responseCollection as $response) {
+            $this->assertFalse(true);
+        }
+    }
 }


### PR DESCRIPTION
I have found a bug with empty response collection in php 7.2 and would fix it.

But afterwards i have seen your changes on master branch. So here is the test I have already written for your changes. ;)