### PR TITLE
Use AMQPChannel::close() in AbstractConsumer

### DIFF
--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -183,14 +183,7 @@ abstract class AbstractConsumer implements Consumer
         } catch (Exception\QueueException $e) {
             $this->logger->error('Exception: ' . $e->getMessage());
             $this->ackOrNackBlock();
-
-            // hack for different drivers
-            $channel = $this->queue->getChannel();
-            if ($channel instanceof Driver\PhpAmqpLib\Channel) {
-                $channel->getResource()->close(); // preferred, but not present in amqp-extension
-            } elseif ($channel instanceof Driver\AmqpExtension\Channel) {
-                $channel->getConnection()->reconnect(); // needed in order to destroy (and close) the channel
-            }
+            $this->queue->getChannel()->getResource()->close();
         }
     }
 


### PR DESCRIPTION
Currently there is a [comment in AbstractConsumer](https://github.com/prolic/HumusAmqp/blob/f516eef998f5a0fe9e868dcd6de7a0f4fe81b0e4/src/AbstractConsumer.php#L190) that amqp extension does not have close method for channel. But according [amqp extension repo](https://github.com/pdezwart/php-amqp/commit/66bfc673df27833e74803e8f3c012c4cbde45d78#diff-a03dbde9209c9eb9001ccf320b605a76) this method is available since version 1.8.0 . And according [README.md](https://github.com/prolic/HumusAmqp/blob/f516eef998f5a0fe9e868dcd6de7a0f4fe81b0e4/README.md) minimal required version for HumusAmqp is even greater - 1.9.3. 
So maybe this small hack can be removed now?