### PR TITLE
[enable_php-enum_version_4] Allow 'marc-mabe/php-enum' in version 4.0.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^7.1",
         "beberlei/assert": "^2.4 || ^3.0",
-        "marc-mabe/php-enum": "^2.2 || ^3.0",
+        "marc-mabe/php-enum": "^2.2 || ^3.0 || ^4.0",
         "psr/log": "^1.0"
     },
     "require-dev": {


### PR DESCRIPTION
Allow marc-mabe/php-enum in version ^4.0, because the usage in the module does allow for it. 