### PR TITLE
symfony/console: ^5.0 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "symfony/console": "^2.5|^3.0",
+        "symfony/console": "^2.5|^3.0|^4.0|^5.0",
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^1.0",
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",

--- a/src/Console/Command/PublishMessageCommand.php
+++ b/src/Console/Command/PublishMessageCommand.php
@@ -191,5 +191,7 @@ class PublishMessageCommand extends AbstractCommand
         }
 
         $output->writeln('Message published');
+
+        return 0;
     }
 }

--- a/src/Console/Command/PurgeQueueCommand.php
+++ b/src/Console/Command/PurgeQueueCommand.php
@@ -82,5 +82,7 @@ class PurgeQueueCommand extends AbstractCommand
         $queue->purge();
 
         $output->writeln('Queue ' . $queueName . ' purged');
+
+        return 0;
     }
 }

--- a/src/Console/Command/SetupFabricCommand.php
+++ b/src/Console/Command/SetupFabricCommand.php
@@ -75,5 +75,7 @@ class SetupFabricCommand extends AbstractCommand
                 $output->writeln('Queue ' . $queue . ' declared');
             }
         }
+
+        return 0;
     }
 }

--- a/src/Console/Command/ShowCommand.php
+++ b/src/Console/Command/ShowCommand.php
@@ -120,6 +120,8 @@ class ShowCommand extends AbstractCommand
                 }
                 break;
         }
+
+        return 0;
     }
 
     /**

--- a/src/Console/Command/StartCallbackConsumerCommand.php
+++ b/src/Console/Command/StartCallbackConsumerCommand.php
@@ -85,5 +85,7 @@ class StartCallbackConsumerCommand extends AbstractCommand
         /* @var Consumer $callbackConsumer */
 
         $callbackConsumer->consume((int) $input->getOption('amount'));
+
+        return 0;
     }
 }

--- a/src/Console/Command/StartJsonRpcServerCommand.php
+++ b/src/Console/Command/StartJsonRpcServerCommand.php
@@ -85,5 +85,7 @@ class StartJsonRpcServerCommand extends AbstractCommand
         /* @var Consumer $jsonRpcServer */
 
         $jsonRpcServer->consume((int) $input->getOption('amount'));
+
+        return 0;
     }
 }


### PR DESCRIPTION
Console actions ready for symfony/console 5.*

Execute command should return int, if not error is thrown:

`PHP Fatal error:  Uncaught TypeError: Return value of "Humus\Amqp\Console\Command\ShowCommand::execute()" must be of the type int, NULL returned. in /var/www/html/vendor/symfony/console/Command/Command.php:258`