### PR TITLE
PHPUnit 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 language: php
 
 php:
+  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ sudo: required
 language: php
 
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "beberlei/assert": "^2.4 || ^3.0",
         "marc-mabe/php-enum": "^2.2 || ^3.0 || ^4.0",
         "psr/log": "^1.0"
@@ -22,7 +22,7 @@
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^1.0",
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",
-        "phpunit/phpunit": "^6.5.14",
+        "phpunit/phpunit": "^8.0",
         "phpspec/prophecy": "^1.10",
         "satooshi/php-coveralls": "^2.0",
         "php-amqplib/php-amqplib": "^2.7.1,<2.9.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "beberlei/assert": "^2.4 || ^3.0",
         "marc-mabe/php-enum": "^2.2 || ^3.0 || ^4.0",
         "psr/log": "^1.0"
@@ -22,7 +22,7 @@
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^1.0",
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^8.0",
         "phpspec/prophecy": "^1.10",
         "satooshi/php-coveralls": "^2.0",
         "php-amqplib/php-amqplib": "^2.7.1,<2.9.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.1",
         "beberlei/assert": "^2.4 || ^3.0",
         "marc-mabe/php-enum": "^2.2 || ^3.0 || ^4.0",
         "psr/log": "^1.0"
@@ -22,7 +22,7 @@
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^1.0",
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^6.5.14",
         "phpspec/prophecy": "^1.10",
         "satooshi/php-coveralls": "^2.0",
         "php-amqplib/php-amqplib": "^2.7.1,<2.9.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^1.0",
         "zendframework/zend-servicemanager": "^2.7 || ^3.0",
-        "phpunit/phpunit": "^8.0",
+        "phpunit/phpunit": "^7.0",
         "phpspec/prophecy": "^1.10",
         "satooshi/php-coveralls": "^2.0",
         "php-amqplib/php-amqplib": "^2.7.1,<2.9.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": "^7.2",
+        "php": "^7.1",
         "beberlei/assert": "^2.4 || ^3.0",
         "marc-mabe/php-enum": "^2.2 || ^3.0 || ^4.0",
         "psr/log": "^1.0"

--- a/tests/AbstractChannelRecoverTest.php
+++ b/tests/AbstractChannelRecoverTest.php
@@ -47,7 +47,7 @@ abstract class AbstractChannelRecoverTest extends TestCase implements CanCreateC
      */
     private $queue;
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         $this->queue->delete();
         $this->exchange->delete();

--- a/tests/AbstractChannelTest.php
+++ b/tests/AbstractChannelTest.php
@@ -45,7 +45,7 @@ abstract class AbstractChannelTest extends TestCase implements CanCreateConnecti
      */
     protected $channel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->connection = $this->createConnection();
         $this->channel = $this->connection->newChannel();

--- a/tests/AbstractExchangeTest.php
+++ b/tests/AbstractExchangeTest.php
@@ -57,7 +57,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
      */
     protected $channel;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $connection = $this->createConnection();
         $this->channel = $connection->newChannel();

--- a/tests/AbstractJsonProducerTest.php
+++ b/tests/AbstractJsonProducerTest.php
@@ -67,7 +67,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
      */
     protected $results = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();

--- a/tests/AbstractPlainProducerTest.php
+++ b/tests/AbstractPlainProducerTest.php
@@ -70,7 +70,7 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
      */
     protected $results = [];
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->callback = function (Envelope $envelope) {
             $this->results[] = $envelope->getBody();

--- a/tests/AbstractQueueTest.php
+++ b/tests/AbstractQueueTest.php
@@ -57,7 +57,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
      */
     protected $queue;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $connection = $this->createConnection();
         $this->channel = $connection->newChannel();

--- a/tests/AmqpExtension/ChannelRecoverTest.php
+++ b/tests/AmqpExtension/ChannelRecoverTest.php
@@ -33,7 +33,7 @@ final class ChannelRecoverTest extends AbstractChannelRecoverTest
 {
     use CreateConnectionTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');

--- a/tests/AmqpExtension/ChannelTest.php
+++ b/tests/AmqpExtension/ChannelTest.php
@@ -35,7 +35,7 @@ final class ChannelTest extends AbstractChannelTest
 {
     use CreateConnectionTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');

--- a/tests/AmqpExtension/ConnectionTest.php
+++ b/tests/AmqpExtension/ConnectionTest.php
@@ -36,7 +36,7 @@ final class ConnectionTest extends AbstractConnectionTest
 {
     use CreateConnectionTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');

--- a/tests/AmqpExtension/ExchangeTest.php
+++ b/tests/AmqpExtension/ExchangeTest.php
@@ -33,7 +33,7 @@ final class ExchangeTest extends AbstractExchangeTest
 {
     use CreateConnectionTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');

--- a/tests/AmqpExtension/JsonProducerTest.php
+++ b/tests/AmqpExtension/JsonProducerTest.php
@@ -33,7 +33,7 @@ final class JsonProducerTest extends AbstractJsonProducerTest
 {
     use CreateConnectionTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');

--- a/tests/AmqpExtension/PlainProducerTest.php
+++ b/tests/AmqpExtension/PlainProducerTest.php
@@ -33,7 +33,7 @@ final class PlainProducerTest extends AbstractPlainProducerTest
 {
     use CreateConnectionTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');

--- a/tests/AmqpExtension/QueueTest.php
+++ b/tests/AmqpExtension/QueueTest.php
@@ -33,7 +33,7 @@ final class QueueTest extends AbstractQueueTest
 {
     use CreateConnectionTrait;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');

--- a/tests/Helper/DeleteOnTearDownTrait.php
+++ b/tests/Helper/DeleteOnTearDownTrait.php
@@ -36,7 +36,7 @@ trait DeleteOnTearDownTrait
      */
     protected $toCleanUp = [];
 
-    protected function tearDown()
+    protected function tearDown(): void
     {
         foreach ($this->toCleanUp as $resource) {
             try {

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -925,9 +925,9 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
         $response1 = $responses->getResponse('request-1');
         $this->assertTrue($response1->isError());
-        $this->assertIsString($response1->data());
+        $this->assertInternalType('string', $response1->data());
         $this->assertNotEmpty($response1->data());
-        $this->assertIsString($response1->error()->data());
+        $this->assertInternalType('string', $response1->error()->data());
         $this->assertNotEmpty($response1->error()->data());
     }
 }

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -925,9 +925,9 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
         $response1 = $responses->getResponse('request-1');
         $this->assertTrue($response1->isError());
-        $this->assertInternalType('string', $response1->data());
+        $this->assertIsString($response1->data());
         $this->assertNotEmpty($response1->data());
-        $this->assertInternalType('string', $response1->error()->data());
+        $this->assertIsString($response1->error()->data());
         $this->assertNotEmpty($response1->error()->data());
     }
 }


### PR DESCRIPTION
Tests for PHPUnit 8 and php7.4

PHPUnit 6 and 7 are no longer supported (https://phpunit.de/supported-versions.html)

PHPUnit 8 require php 7.2 so it means no support for php 7.1 in travis and composer.json