### PR TITLE
Require PHP 7.4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@
 nbproject
 composer.lock
 .php_cs.cache
+.phpunit.result.cache
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,7 @@ before_script:
   - sudo rabbitmqctl set_permissions -p /humus-amqp-test guest ".*" ".*" ".*"
 
 script:
-  - php -dzend_extension=xdebug.so ./vendor/bin/phpunit --exclude-group=ssl --coverage-text --coverage-clover ./build/logs/clover.xml
+  - ./vendor/bin/phpunit --exclude-group=ssl --coverage-text --coverage-clover ./build/logs/clover.xml
   - rm -rf rabbitmq-c
   - rm -rf php-amqp
   - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: required
 language: php
 
 php:
-  - 7.2
-  - 7.3
   - 7.4
 
 services:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Humus Amqp
 
-PHP 7.2 AMQP library
+PHP 7.4 AMQP library
 
 [![Build Status](https://travis-ci.org/prolic/HumusAmqp.svg?branch=master)](https://travis-ci.org/prolic/HumusAmqp)
 [![Coverage Status](https://coveralls.io/repos/github/prolic/HumusAmqp/badge.svg?branch=master)](https://coveralls.io/github/prolic/HumusAmqp?branch=master)
@@ -11,14 +11,14 @@ PHP 7.2 AMQP library
 
 ## Overview
 
-PHP 7.2 AMQP libray supporting multiple drivers and providing full-featured Consumer, Producer, and JSON-RPC Client / Server implementations.
+PHP 7.4 AMQP libray supporting multiple drivers and providing full-featured Consumer, Producer, and JSON-RPC Client / Server implementations.
 
 The JSON-RPC part implements [JSON-RPC 2.0 Specification](http://www.jsonrpc.org/specification).
 
 Current supported drivers are: [php-amqp](https://github.com/pdezwart/php-amqp) and [PhpAmqpLib](https://github.com/php-amqplib/php-amqplib).
 
 php-amqp needs at least to be v1.9.3
-php-amqplib needs at least to be v2.7.1
+php-amqplib needs at least to be v2.11.0
 
 This library ships with `container-interop` factories that help you setting up everything.
 

--- a/composer.json
+++ b/composer.json
@@ -12,22 +12,23 @@
         }
     ],
     "require": {
-        "php": "^7.2",
-        "beberlei/assert": "^2.4 || ^3.0",
-        "marc-mabe/php-enum": "^2.2 || ^3.0 || ^4.0",
+        "php": "^7.4",
+        "ext-json": "*",
+        "beberlei/assert": "^3.2.7",
+        "marc-mabe/php-enum": "^4.2",
         "psr/log": "^1.0"
     },
     "require-dev": {
-        "symfony/console": "^2.5|^3.0|^4.0|^5.0",
+        "symfony/console": "^5.0",
         "psr/container": "^1.0",
         "sandrokeil/interop-config": "^1.0",
-        "laminas/laminas-servicemanager": "^2.7 || ^3.0",
-        "phpunit/phpunit": "^8.0",
+        "laminas/laminas-servicemanager": "^3.0",
+        "phpunit/phpunit": "^8.5",
         "phpspec/prophecy": "^1.10",
         "satooshi/php-coveralls": "^2.0",
         "php-amqplib/php-amqplib": "^2.11",
-        "malukenho/docheader": "^0.1.4",
-        "friendsofphp/php-cs-fixer": "^2.16.1"
+        "malukenho/docheader": "^0.1.8",
+        "prooph/php-cs-fixer-config": "^0.3"
     },
     "conflict": {
         "sandrokeil/interop-config": "<1.0",

--- a/docs/articles/consumers.rst
+++ b/docs/articles/consumers.rst
@@ -114,9 +114,17 @@ Set up the consumer
 
     <?php
 
-    $logger = new \Psr\Log\NullLogger();
+    use Humus\Amqp\CallbackConsumer;
+    use Humus\Amqp\DeliveryResult;
+    use Humus\Amqp\Driver\AmqpExtension\Connection;
+    use Humus\Amqp\Envelope;
+    use Humus\Amqp\FlushDeferredResult;
+    use Humus\Amqp\Queue;
+    use Psr\Log\NullLogger;
 
-    $connection = new \Humus\Amqp\Driver\AmqpExtension\Connection();
+    $logger = new NullLogger();
+
+    $connection = new Connection();
     $connection->connect();
 
     $channel = $connection->newChannel();
@@ -126,16 +134,16 @@ Set up the consumer
     $queue = $channel->newQueue();
     $queue->setName('test-queue');
 
-    $consumer = new \Humus\Amqp\CallbackConsumer(
+    $consumer = new CallbackConsumer(
         $queue,
         $logger,
         12.5, // idle timeout, float in seconds
-        function (\Humus\Amqp\Envelope $envelope, \Humus\Amqp\Queue $queue) {
+        function (Envelope $envelope,Queue $queue): DeliveryResult {
             echo $envelope->getBody();
-            return \Humus\Amqp\DeliveryResult::MSG_DEFER();
+            return DeliveryResult::MSG_DEFER();
         },
-        function (\Humus\Amqp\Queue $queue) {
-            return \Humus\Amqp\FlushDeferredResult::MSG_ACK();
+        function (Queue $queue) {
+            return FlushDeferredResult::MSG_ACK();
         },
         null, // no custom error callback
         'demo-consumer-tag'

--- a/docs/articles/consumers.rst
+++ b/docs/articles/consumers.rst
@@ -19,9 +19,13 @@ and the queue) and returns a delivery result. A very simple callback would look 
 
     <?php
 
-    $callback = function(\Humus\Amqp\Envelope $envelope, \Humus\Amqp\Queue $queue) {
+    use Humus\Amqp\DeliveryResult;
+    use Humus\Amqp\Envelope;
+    use Humus\Amqp\Queue;
+
+    $callback = function(Envelope $envelope, Queue $queue): DeliveryResult {
         echo $envelope->getBody();
-        return \Humus\Amqp\DeliveryResult::MSG_ACK();
+        return DeliveryResult::MSG_ACK();
     }
 
 The delivery result will signal the consumer whether it should ack, nack, reject, reject and
@@ -142,7 +146,7 @@ Set up the consumer
             echo $envelope->getBody();
             return DeliveryResult::MSG_DEFER();
         },
-        function (Queue $queue) {
+        function (Queue $queue): FlushDeferredResult {
             return FlushDeferredResult::MSG_ACK();
         },
         null, // no custom error callback
@@ -158,24 +162,29 @@ Set up the consumer using config and factory
 
     <?php
 
-    // declare callbacks as invokable classes first
+    use Humus\Amqp\DeliveryResult;
+    use Humus\Amqp\Envelope;
+    use Humus\Amqp\FlushDeferredResult;
+    use Humus\Amqp\Queue;
 
     namespace My
     {
+        // declare callbacks as invokable classes first
+
         class EchoCallback
         {
-            public function __invoke(\Humus\Amqp\Envelope $envelope, \Humus\Amqp\Queue $queue)
+            public function __invoke(Envelope $envelope, Queue $queue): DeliveryResult
             {
                 echo $envelope->getBody();
-                return \Humus\Amqp\DeliveryResult::MSG_DEFER();
+                return DeliveryResult::MSG_DEFER();
             }
         }
 
         class FlushDeferredCallback
         {
-            public function (\Humus\Amqp\Queue $queue)
+            public function (Queue $queue): FlushDeferredResult
             {
-                return \Humus\Amqp\FlushDeferredResult::MSG_ACK();
+                return FlushDeferredResult::MSG_ACK();
             }
         }
     }

--- a/docs/articles/exchanges.rst
+++ b/docs/articles/exchanges.rst
@@ -826,7 +826,7 @@ none of the bindings match), the message is returned to the producer.
             string $routingKey,
             Envelope $envelope,
             string $body
-        ) use (&$result) {
+        ) use (&$result): bool {
             $result[] = 'Message returned';
             $result[] = func_get_args();
             return false;

--- a/docs/articles/producers.rst
+++ b/docs/articles/producers.rst
@@ -188,7 +188,7 @@ Publishing messages with confirm select
         function (
             int $deliveryTag,
             bool $multiple = false
-        ) use (&$cnt, &$result) {
+        ) use (&$cnt, &$result): bool {
             $result[] = 'Message acked';
             $result[] = func_get_args();
             return --$cnt > 0;
@@ -197,7 +197,7 @@ Publishing messages with confirm select
             int $deliveryTag,
             bool $multiple,
             bool $requeue
-        ) use (&$result) {
+        ) use (&$result): bool {
             $result[] = 'Message nacked';
             $result[] = func_get_args();
             return false;
@@ -225,7 +225,7 @@ Publishing messages as mandatory
             string $routingKey,
             Envelope $envelope,
             string $body
-        ) {
+        ): void {
             throw new \RuntimeException('Message returned: ' . $replyText);
         }
     );

--- a/docs/articles/rpc.rst
+++ b/docs/articles/rpc.rst
@@ -12,6 +12,8 @@ A sample configuration might look like this, more details and explanation will b
 
 .. code-block:: php
 
+    use Humus\Amqp\JsonRpc;
+
     return [
         'dependencies' => [
             'factories' => [
@@ -19,8 +21,8 @@ A sample configuration might look like this, more details and explanation will b
                 'default-amqp-connection' => [Container\ConnectionFactory::class, 'default'],
                 'demo-rpc-server' => [Container\JsonRpcServerFactory::class, 'demo-rpc-server'],
                 'timestwo' => function () {
-                    return function (\Humus\Amqp\JsonRpc\Request $request): \Humus\Amqp\JsonRpc\Response {
-                        return \Humus\Amqp\JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 2);
+                    return function (JsonRpc\Request $request): JsonRpc\Response {
+                        return JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 2);
                     };
                 },
             ],
@@ -77,8 +79,10 @@ callback is simply turning a Request into a Response like this:
 
 .. code-block:: php
 
-    function (\Humus\Amqp\JsonRpc\Request $request): \Humus\Amqp\JsonRpc\Response {
-        return \Humus\Amqp\JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 2);
+    use Humus\Amqp\JsonRpc;
+
+    function (JsonRpc\Request $request): JsonRpc\Response {
+        return JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 2);
     }
 
 For the callback function consider this:
@@ -92,16 +96,18 @@ different results, based on the method. For example:
 
 .. code-block:: php
 
-    function (\Humus\Amqp\JsonRpc\Request $request): \Humus\Amqp\JsonRpc\Response {
+    use Humus\Amqp\JsonRpc;
+
+    function (JsonRpc\Request $request): JsonRpc\Response {
         switch ($request->method()) {
             case 'times2':
-                return \Humus\Amqp\JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 2);
+                return JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 2);
             case 'times3:
-                return \Humus\Amqp\JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 3);
+                return JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() * 3);
             case 'plus5':
-                return \Humus\Amqp\JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() + 5);
+                return JsonRpc\JsonRpcResponse::withResult($request->id(), $request->params() + 5);
             default:
-                return \Humus\Amqp\JsonRpc\JsonRpcResponse::withError($request->id(), new \Humus\Amqp\JsonRpc\JsonRpcError(32601));
+                return JsonRpc\JsonRpcResponse::withError($request->id(), new JsonRpc\JsonRpcError(32601));
         }
     }
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ Documentation for `HumusAMQP <http://www.github.com/prolic/HumusAmqp/>`_
 Overview
 --------
 
-PHP 7.2 AMQP libray supporting multiple drivers and providing full-featured Consumer, Producer, and JSON-RPC Client / Server implementations.
+PHP 7.4 AMQP libray supporting multiple drivers and providing full-featured Consumer, Producer, and JSON-RPC Client / Server implementations.
 
 The JSON-RPC part implements `JSON-RPC 2.0 Specification <http://www.jsonrpc.org/specification>`_.
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <phpunit
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.0/phpunit.xsd"
+        xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/8.5/phpunit.xsd"
         backupGlobals="false"
         backupStaticAttributes="false"
         colors="true"

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -24,7 +24,7 @@ namespace Humus\Amqp;
 
 use Assert\Assertion;
 use Humus\Amqp\Exception\RuntimeException;
-use HumusAmqp\Util\Json;
+use Humus\Amqp\Util\Json;
 use Psr\Log\LoggerInterface;
 
 abstract class AbstractConsumer implements Consumer

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -24,6 +24,7 @@ namespace Humus\Amqp;
 
 use Assert\Assertion;
 use Humus\Amqp\Exception\RuntimeException;
+use HumusAmqp\Util\Json;
 use Psr\Log\LoggerInterface;
 
 abstract class AbstractConsumer implements Consumer
@@ -285,7 +286,7 @@ abstract class AbstractConsumer implements Consumer
         } elseif ('reconfigure' === $envelope->getType()) {
             $this->logger->info('Reconfigure message received');
             try {
-                list($idleTimeout, $target, $prefetchSize, $prefetchCount) = \json_decode($envelope->getBody());
+                list($idleTimeout, $target, $prefetchSize, $prefetchCount) = Json::decode($envelope->getBody());
 
                 if (\is_numeric($idleTimeout)) {
                     $idleTimeout = (float) $idleTimeout;

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -38,7 +38,7 @@ abstract class AbstractConsumer implements Consumer
     protected float $idleTimeout;
     protected int $blockSize;
     protected float $timestampLastAck;
-    protected float $timestampLastMessage;
+    protected ?float $timestampLastMessage = null;
     protected int $target;
 
     /**

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -33,7 +33,7 @@ abstract class AbstractConsumer implements Consumer
     protected string $consumerTag;
     protected int $countMessagesConsumed = 0;
     protected int $countMessagesUnacked = 0;
-    protected ?int $lastDeliveryTag;
+    protected ?int $lastDeliveryTag = null;
     protected bool $keepAlive = true;
     protected float $idleTimeout;
     protected int $blockSize;

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -37,7 +37,7 @@ abstract class AbstractConsumer implements Consumer
     protected bool $keepAlive = true;
     protected float $idleTimeout;
     protected int $blockSize;
-    protected float $timestampLastAck;
+    protected ?float $timestampLastAck = null;
     protected ?float $timestampLastMessage = null;
     protected int $target;
 

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -68,11 +68,12 @@ abstract class AbstractConsumer implements Consumer
             $this->timestampLastAck = microtime(true);
         }
 
-        $callback = function (Envelope $envelope) {
+        $callback = function (Envelope $envelope): bool {
             try {
                 $processFlag = $this->handleDelivery($envelope, $this->queue);
             } catch (\Throwable $e) {
                 $this->logger->error('Exception during handleDelivery: ' . $e->getMessage());
+
                 if ($this->handleException($e)) {
                     $processFlag = DeliveryResult::MSG_REJECT_REQUEUE();
                 } else {
@@ -97,6 +98,8 @@ abstract class AbstractConsumer implements Consumer
 
                 return false;
             }
+
+            return true;
         };
 
         try {

--- a/src/AbstractConsumer.php
+++ b/src/AbstractConsumer.php
@@ -65,7 +65,7 @@ abstract class AbstractConsumer implements Consumer
         $this->blockSize = $this->queue->getChannel()->getPrefetchCount();
 
         if (! $this->timestampLastAck) {
-            $this->timestampLastAck = microtime(true);
+            $this->timestampLastAck = \microtime(true);
         }
 
         $callback = function (Envelope $envelope): bool {
@@ -83,7 +83,7 @@ abstract class AbstractConsumer implements Consumer
 
             $this->handleProcessFlag($envelope, $processFlag);
 
-            $now = microtime(true);
+            $now = \microtime(true);
 
             if ($this->countMessagesUnacked > 0
                 && ($this->countMessagesUnacked === $this->blockSize
@@ -147,10 +147,10 @@ abstract class AbstractConsumer implements Consumer
             return true;
         }
 
-        if (! is_bool($requeue)) {
+        if (! \is_bool($requeue)) {
             throw new RuntimeException(sprintf(
                 'The error callback must returns boolean or null, given "%s".',
-                is_object($requeue) ? get_class($requeue) : gettype($requeue)
+                \is_object($requeue) ? \get_class($requeue) : \gettype($requeue)
             ));
         }
 
@@ -201,13 +201,13 @@ abstract class AbstractConsumer implements Consumer
             case DeliveryResult::MSG_ACK():
                 $this->countMessagesUnacked++;
                 $this->lastDeliveryTag = $envelope->getDeliveryTag();
-                $this->timestampLastMessage = microtime(true);
+                $this->timestampLastMessage = \microtime(true);
                 $this->ack();
                 break;
             case DeliveryResult::MSG_DEFER():
                 $this->countMessagesUnacked++;
                 $this->lastDeliveryTag = $envelope->getDeliveryTag();
-                $this->timestampLastMessage = microtime(true);
+                $this->timestampLastMessage = \microtime(true);
                 break;
         }
     }
@@ -229,7 +229,7 @@ abstract class AbstractConsumer implements Consumer
             $delta ? $this->countMessagesUnacked / $delta : 0
         ));
 
-        $this->timestampLastAck = microtime(true);
+        $this->timestampLastAck = \microtime(true);
         $this->countMessagesUnacked = 0;
     }
 
@@ -285,9 +285,9 @@ abstract class AbstractConsumer implements Consumer
         } elseif ('reconfigure' === $envelope->getType()) {
             $this->logger->info('Reconfigure message received');
             try {
-                list($idleTimeout, $target, $prefetchSize, $prefetchCount) = json_decode($envelope->getBody());
+                list($idleTimeout, $target, $prefetchSize, $prefetchCount) = \json_decode($envelope->getBody());
 
-                if (is_numeric($idleTimeout)) {
+                if (\is_numeric($idleTimeout)) {
                     $idleTimeout = (float) $idleTimeout;
                 }
                 Assertion::float($idleTimeout);

--- a/src/AbstractOptions.php
+++ b/src/AbstractOptions.php
@@ -57,7 +57,7 @@ abstract class AbstractOptions
             $options = $options->toArray();
         }
 
-        if (! is_array($options) && ! $options instanceof Traversable) {
+        if (! \is_array($options) && ! $options instanceof Traversable) {
             throw new Exception\InvalidArgumentException(
                 sprintf(
                     'Parameter provided to %s must be an %s, %s or %s',
@@ -81,16 +81,16 @@ abstract class AbstractOptions
         $array = [];
 
         $transform = function ($letters): string {
-            $letter = array_shift($letters);
+            $letter = \array_shift($letters);
 
-            return '_' . strtolower($letter);
+            return '_' . \strtolower($letter);
         };
 
         foreach ($this as $key => $value) {
             if ($key === '__strictMode__') {
                 continue;
             }
-            $normalizedKey = preg_replace_callback('/([A-Z])/', $transform, $key);
+            $normalizedKey = \preg_replace_callback('/([A-Z])/', $transform, $key);
             $array[$normalizedKey] = $value;
         }
 
@@ -113,7 +113,7 @@ abstract class AbstractOptions
     {
         $setter = 'set' . str_replace('_', '', $key);
 
-        if (is_callable([$this, $setter])) {
+        if (\is_callable([$this, $setter])) {
             $this->{$setter}($value);
 
             return;
@@ -144,7 +144,7 @@ abstract class AbstractOptions
     {
         $getter = 'get' . str_replace('_', '', $key);
 
-        if (is_callable([$this, $getter])) {
+        if (\is_callable([$this, $getter])) {
             return $this->{$getter}();
         }
 

--- a/src/AbstractOptions.php
+++ b/src/AbstractOptions.php
@@ -24,24 +24,16 @@ namespace Humus\Amqp;
 
 use Traversable;
 
-/**
- * Class AbstractOptions
- * @package Humus\Amqp
- */
 abstract class AbstractOptions
 {
     /**
      * We use the __ prefix to avoid collisions with properties in
      * user-implementations.
-     *
-     * @var bool
      */
-    protected $__strictMode__ = true;
+    protected bool $__strictMode__ = true;
 
     /**
-     * Constructor
-     *
-     * @param  array|Traversable|null $options
+     * @param array|Traversable|null $options
      */
     public function __construct($options = null)
     {
@@ -54,10 +46,12 @@ abstract class AbstractOptions
      * Set one or more configuration properties
      *
      * @param  array|Traversable|AbstractOptions $options
-     * @throws Exception\InvalidArgumentException
+     *
      * @return AbstractOptions Provides fluent interface
+     *
+     * @throws Exception\InvalidArgumentException
      */
-    public function setFromArray($options)
+    public function setFromArray($options): AbstractOptions
     {
         if ($options instanceof self) {
             $options = $options->toArray();
@@ -82,12 +76,7 @@ abstract class AbstractOptions
         return $this;
     }
 
-    /**
-     * Cast to array
-     *
-     * @return array
-     */
-    public function toArray()
+    public function toArray(): array
     {
         $array = [];
         $transform = function ($letters) {
@@ -110,12 +99,15 @@ abstract class AbstractOptions
      * Set a configuration property
      *
      * @see ParameterObject::__set()
+     *
      * @param string $key
      * @param mixed $value
-     * @throws Exception\BadMethodCallException
+     *
      * @return void
+     *
+     * @throws Exception\BadMethodCallException
      */
-    public function __set($key, $value)
+    public function __set(string $key, $value): void
     {
         $setter = 'set' . str_replace('_', '', $key);
 
@@ -139,11 +131,14 @@ abstract class AbstractOptions
      * Get a configuration property
      *
      * @see ParameterObject::__get()
+     *
      * @param string $key
-     * @throws Exception\BadMethodCallException
+     *
      * @return mixed
+     *
+     * @throws Exception\BadMethodCallException
      */
-    public function __get($key)
+    public function __get(string $key)
     {
         $getter = 'get' . str_replace('_', '', $key);
 
@@ -161,10 +156,8 @@ abstract class AbstractOptions
     /**
      * Test if a configuration property is null
      * @see ParameterObject::__isset()
-     * @param string $key
-     * @return bool
      */
-    public function __isset($key)
+    public function __isset(string $key): bool
     {
         $getter = 'get' . str_replace('_', '', $key);
 
@@ -175,11 +168,8 @@ abstract class AbstractOptions
      * Set a configuration property to NULL
      *
      * @see ParameterObject::__unset()
-     * @param string $key
-     * @throws Exception\InvalidArgumentException
-     * @return void
      */
-    public function __unset($key)
+    public function __unset(string $key): void
     {
         try {
             $this->__set($key, null);

--- a/src/AbstractOptions.php
+++ b/src/AbstractOptions.php
@@ -79,11 +79,13 @@ abstract class AbstractOptions
     public function toArray(): array
     {
         $array = [];
-        $transform = function ($letters) {
+
+        $transform = function ($letters): string {
             $letter = array_shift($letters);
 
             return '_' . strtolower($letter);
         };
+
         foreach ($this as $key => $value) {
             if ($key === '__strictMode__') {
                 continue;

--- a/src/AbstractProducer.php
+++ b/src/AbstractProducer.php
@@ -24,30 +24,12 @@ namespace Humus\Amqp;
 
 use Humus\Amqp\Exception\ChannelException;
 
-/**
- * Class AbstractProducer
- * @package Humus\Amqp
- */
 abstract class AbstractProducer implements Producer
 {
-    /**
-     * @var Exchange
-     */
-    protected $exchange;
+    protected Exchange $exchange;
+    protected array $defaultAttributes;
 
-    /**
-     * @var array
-     */
-    protected $defaultAttributes;
-
-    /**
-     * Constructor
-     *
-     * @param Exchange $exchange
-     * @param array|null $defaultAttributes
-     * @throws ChannelException
-     */
-    public function __construct(Exchange $exchange, array $defaultAttributes = null)
+    public function __construct(Exchange $exchange, ?array $defaultAttributes = null)
     {
         $this->exchange = $exchange;
 
@@ -56,66 +38,42 @@ abstract class AbstractProducer implements Producer
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function startTransaction()
+    public function startTransaction(): void
     {
         $this->exchange->getChannel()->startTransaction();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->exchange->getChannel()->commitTransaction();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->exchange->getChannel()->rollbackTransaction();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function confirmSelect()
+    public function confirmSelect(): void
     {
         $this->exchange->getChannel()->confirmSelect();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null)
+    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null): void
     {
         $this->exchange->getChannel()->setConfirmCallback($ackCallback, $nackCallback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function waitForConfirm(float $timeout = 0.0)
+    public function waitForConfirm(float $timeout = 0.0): void
     {
         $this->exchange->getChannel()->waitForConfirm($timeout);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setReturnCallback(callable $returnCallback = null)
+    public function setReturnCallback(callable $returnCallback = null): void
     {
         $this->exchange->getChannel()->setReturnCallback($returnCallback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function waitForBasicReturn(float $timeout = 0.0)
+    public function waitForBasicReturn(float $timeout = 0.0): void
     {
         $this->exchange->getChannel()->waitForBasicReturn($timeout);
     }

--- a/src/AbstractProducer.php
+++ b/src/AbstractProducer.php
@@ -22,8 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-use Humus\Amqp\Exception\ChannelException;
-
 abstract class AbstractProducer implements Producer
 {
     protected Exchange $exchange;

--- a/src/CallbackConsumer.php
+++ b/src/CallbackConsumer.php
@@ -28,24 +28,10 @@ use Psr\Log\LoggerInterface;
  * The consumer attaches to a single queue
  *
  * The used block size is the configured prefetch size of the queue's channel
- *
- * Class CallbackConsumer
- * @package Humus\Amqp
  */
 final class CallbackConsumer extends AbstractConsumer
 {
     /**
-     * Constructor
-     *
-     * @param Queue $queue
-     * @param LoggerInterface $logger
-     * @param float $idleTimeout in seconds
-     * @param callable $deliveryCallback,
-     * @param callable|null $flushCallback,
-     * @param callable|null $errorCallback
-     * @param string $consumerTag
-     * @throws Exception\InvalidArgumentException
-     *
      * Callback functions with all arguments have the following signature:
      *
      *      function deliveryCallback(Envelope $envelope, Queue $queue): DeliveryResult;

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -22,9 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-use Humus\Amqp\Exception\ChannelException;
-use Humus\Amqp\Exception\QueueException;
-
 /**
  * Represents a AMQP channel between PHP and a AMQP server.
  */

--- a/src/Channel.php
+++ b/src/Channel.php
@@ -27,31 +27,16 @@ use Humus\Amqp\Exception\QueueException;
 
 /**
  * Represents a AMQP channel between PHP and a AMQP server.
- *
- * Interface Channel
- * @package Humus\Amqp
  */
 interface Channel
 {
     /**
      * Return the internal channel implementation based on the used driver
-     *
-     * @return object
      */
-    public function getResource();
+    public function getResource(): object;
 
-    /**
-     * Check the channel connection.
-     *
-     * @return bool Indicates whether the channel is connected.
-     */
     public function isConnected(): bool;
 
-    /**
-     * Return internal channel ID
-     *
-     * @return int
-     */
     public function getChannelId(): int;
 
     /**
@@ -63,16 +48,11 @@ interface Channel
      * prefetch message count setting will be ignored. If the call to either
      * Queue::consume() or Queue::get() is done with the Constants::AMQP_AUTOACK
      * flag set, this setting will be ignored.
-     *
-     * @param int $size The window size, in octets, to prefetch.
-     * @return void
      */
-    public function setPrefetchSize(int $size);
+    public function setPrefetchSize(int $size): void;
 
     /**
      * Get the window size to prefetch from the broker.
-     *
-     * @return int
      */
     public function getPrefetchSize(): int;
 
@@ -83,16 +63,11 @@ interface Channel
      * Queue::consume() or Queue::get(). Any call to this method will
      * automatically set the prefetch window size to 0, meaning that the
      * prefetch window size setting will be ignored.
-     *
-     * @param int $count The number of messages to prefetch.
-     * @return void
      */
-    public function setPrefetchCount(int $count);
+    public function setPrefetchCount(int $count): void;
 
     /**
      * Get the number of messages to prefetch from the broker.
-     *
-     * @return int
      */
     public function getPrefetchCount(): int;
 
@@ -113,64 +88,49 @@ interface Channel
      *
      * @param int $size  The window size, in octets, to prefetch.
      * @param int $count The number of messages to prefetch.
+     *
      * @return void
      */
-    public function qos(int $size, int $count);
+    public function qos(int $size, int $count): void;
 
     /**
      * Start a transaction.
      *
      * This method must be called on the given channel prior to calling
      * Channel::commitTransaction() or Channel::rollbackTransaction().
-     *
-     * @return void
      */
-    public function startTransaction();
+    public function startTransaction(): void;
 
     /**
      * Commit a pending transaction.
-     *
-     * @return void
      */
-    public function commitTransaction();
+    public function commitTransaction(): void;
 
     /**
      * Rollback a transaction.
      *
      * Rollback an existing transaction. Channel::startTransaction() must
      * be called prior to this.
-     *
-     * @return void
      */
-    public function rollbackTransaction();
+    public function rollbackTransaction(): void;
 
     /**
      * Get the Connection object in use
-     *
-     * @return Connection
      */
     public function getConnection(): Connection;
 
     /**
      * Redeliver unacknowledged messages.
-     *
-     * @param bool $requeue
-     * @return void
      */
-    public function basicRecover(bool $requeue = true);
+    public function basicRecover(bool $requeue = true): void;
 
     /**
      * Set the channel to use publisher acknowledgements. This can only used on a non-transactional channel.
-     *
-     * @return void
      */
-    public function confirmSelect();
+    public function confirmSelect(): void;
 
     /**
      * Set callback to process basic.ack and basic.nac AMQP server methods (applicable when channel in confirm mode).
-     *
-     * @param callable|null $ackCallback
-     * @param callable|null $nackCallback
      *
      * Callback functions with all arguments have the following signature:
      *
@@ -181,28 +141,18 @@ interface Channel
      *
      * Note, basic.nack server method will only be delivered if an internal error occurs in the Erlang process
      * responsible for a queue (see https://www.rabbitmq.com/confirms.html for details).
-     *
-     * @return void
      */
-    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null);
+    public function setConfirmCallback(?callable $ackCallback = null, ?callable $nackCallback = null): void;
 
     /**
      * Wait until all messages published since the last call have been either ack'd or nack'd by the broker.
      *
      * Note, this method also catch all basic.return message from server.
-     *
-     * @param float $timeout Timeout in seconds. May be fractional.
-     * @return void
-     * @throws ChannelException
-     * @throws QueueException
      */
-    public function waitForConfirm(float $timeout = 0.0);
+    public function waitForConfirm(float $timeout = 0.0): void;
 
     /**
      * Set callback to process basic.return AMQP server method
-     *
-     * @param callable|null $returnCallback
-     * @return void
      *
      * Callback function with all arguments has the following signature:
      *
@@ -214,27 +164,15 @@ interface Channel
      *                        string $body): bool;
      *
      * and should return boolean false when wait loop should be canceled.
-     *
      */
-    public function setReturnCallback(callable $returnCallback = null);
+    public function setReturnCallback(?callable $returnCallback = null): void;
 
     /**
      * Start wait loop for basic.return AMQP server methods
-     *
-     * @param float $timeout Timeout in seconds. May be fractional.
-     * @return void
-     * @throws ChannelException
-     * @throws QueueException
      */
-    public function waitForBasicReturn(float $timeout = 0.0);
+    public function waitForBasicReturn(float $timeout = 0.0): void;
 
-    /**
-     * @return Exchange
-     */
     public function newExchange(): Exchange;
 
-    /**
-     * @return Queue
-     */
     public function newQueue(): Queue;
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -24,9 +24,6 @@ namespace  Humus\Amqp;
 
 /**
  * Represents a AMQP connection between PHP and a AMQP server.
- *
- * Interface Connection
- * @package Humus\Amqp
  */
 interface Connection
 {
@@ -34,8 +31,6 @@ interface Connection
      * Check whether the connection to the AMQP broker is still valid.
      *
      * It does so by checking the return status of the last connect-command.
-     *
-     * @return bool True if connected, false otherwise.
      */
     public function isConnected(): bool;
 
@@ -43,30 +38,21 @@ interface Connection
      * Establish a transient connection with the AMQP broker.
      *
      * This method will initiate a connection with the AMQP broker.
-     *
-     * @return bool TRUE on success or throw an exception on failure.
      */
-    public function connect();
+    public function connect(): bool;
 
     /**
      * Closes the transient connection with the AMQP broker.
      *
      * This method will close an open connection with the AMQP broker.
-     *
-     * @return bool true if connection was successfully closed, false otherwise.
      */
-    public function disconnect();
+    public function disconnect(): bool;
 
     /**
      * Close any open transient connections and initiate a new one with the AMQP broker.
-     *
-     * @return bool TRUE on success or FALSE on failure.
      */
     public function reconnect(): bool;
 
-    /**
-     * @return ConnectionOptions
-     */
     public function getOptions(): ConnectionOptions;
 
     /**
@@ -74,8 +60,5 @@ interface Connection
      */
     public function getResource();
 
-    /**
-     * @return Channel
-     */
     public function newChannel(): Channel;
 }

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -39,26 +39,26 @@ interface Connection
      *
      * This method will initiate a connection with the AMQP broker.
      */
-    public function connect(): bool;
+    public function connect(): void;
 
     /**
      * Closes the transient connection with the AMQP broker.
      *
      * This method will close an open connection with the AMQP broker.
      */
-    public function disconnect(): bool;
+    public function disconnect(): void;
 
     /**
      * Close any open transient connections and initiate a new one with the AMQP broker.
      */
-    public function reconnect(): bool;
+    public function reconnect(): void;
 
     public function getOptions(): ConnectionOptions;
 
     /**
      * @return mixed
      */
-    public function getResource();
+    public function getResource(): object;
 
     public function newChannel(): Channel;
 }

--- a/src/ConnectionOptions.php
+++ b/src/ConnectionOptions.php
@@ -22,310 +22,164 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-/**
- * Class ConnectionOptions
- * @package Humus\Amqp
- */
 class ConnectionOptions extends AbstractOptions
 {
-    /**
-     * @var string
-     */
-    protected $host = 'localhost';
+    protected string $host = 'localhost';
+    protected int $port = 5672;
+    protected string $login = 'guest';
+    protected string $password = 'guest';
+    protected string $vhost = '/';
+    protected bool $persistent = false;
+    protected float $connectTimeout = 1.00; //secs
+    protected float $readTimeout = 1.00; // secs
+    protected float $writeTimeout = 1.00; // secs
+    protected int $heartbeat = 0;
+    protected ?string $cacert = null;
+    protected ?string $cert = null;
+    protected ?string $key = null;
+    protected ?bool $verify = null;
 
-    /**
-     * @var int
-     */
-    protected $port = 5672;
-
-    /**
-     * @var string
-     */
-    protected $login = 'guest';
-
-    /**
-     * @var string
-     */
-    protected $password = 'guest';
-
-    /**
-     * @var string
-     */
-    protected $vhost = '/';
-
-    /**
-     * @var bool
-     */
-    protected $persistent = false;
-
-    /**
-     * @var float
-     */
-    protected $connectTimeout = 1.00; //secs
-
-    /**
-     * @var float
-     */
-    protected $readTimeout = 1.00; // secs
-
-    /**
-     * @var float
-     */
-    protected $writeTimeout = 1.00; // secs
-
-    /**
-     * @var int
-     */
-    protected $heartbeat = 0;
-
-    /**
-     * @var string
-     */
-    protected $cacert = null;
-
-    /**
-     * @var string
-     */
-    protected $cert = null;
-
-    /**
-     * @var string
-     */
-    protected $key = null;
-
-    /**
-     * @var bool|null
-     */
-    protected $verify = null;
-
-    /**
-     * @param string $host
-     */
-    public function setHost(string $host)
+    public function setHost(string $host): void
     {
         $this->host = $host;
     }
 
-    /**
-     * @return string
-     */
     public function getHost(): string
     {
         return $this->host;
     }
 
-    /**
-     * @param string $password
-     */
-    public function setPassword(string $password)
+    public function setPassword(string $password): void
     {
         $this->password = $password;
     }
 
-    /**
-     * @return string
-     */
     public function getPassword(): string
     {
         return $this->password;
     }
 
-    /**
-     * @param bool $persistent
-     */
-    public function setPersistent(bool $persistent)
+    public function setPersistent(bool $persistent): void
     {
         $this->persistent = $persistent;
     }
 
-    /**
-     * @return bool
-     */
     public function getPersistent(): bool
     {
         return $this->persistent;
     }
 
-    /**
-     * @param int $port
-     */
-    public function setPort(int $port)
+    public function setPort(int $port): void
     {
         $this->port = $port;
     }
 
-    /**
-     * @return int
-     */
     public function getPort(): int
     {
         return $this->port;
     }
 
-    /**
-     * @return float
-     */
     public function getConnectTimeout(): float
     {
         return $this->connectTimeout;
     }
 
-    /**
-     * @param float $connectTimeout
-     */
-    public function setConnectTimeout(float $connectTimeout)
+    public function setConnectTimeout(float $connectTimeout): void
     {
         $this->connectTimeout = $connectTimeout;
     }
 
-    /**
-     * @param float $readTimeout
-     */
-    public function setReadTimeout(float $readTimeout)
+    public function setReadTimeout(float $readTimeout): void
     {
         $this->readTimeout = $readTimeout;
     }
 
-    /**
-     * @return float
-     */
     public function getReadTimeout(): float
     {
         return $this->readTimeout;
     }
 
-    /**
-     * @param string $login
-     */
-    public function setLogin(string $login)
+    public function setLogin(string $login): void
     {
         $this->login = $login;
     }
 
-    /**
-     * @return string
-     */
     public function getLogin(): string
     {
         return $this->login;
     }
 
-    /**
-     * @param string $vhost
-     */
-    public function setVhost(string $vhost)
+    public function setVhost(string $vhost): void
     {
         $this->vhost = $vhost;
     }
 
-    /**
-     * @return string
-     */
     public function getVhost(): string
     {
         return $this->vhost;
     }
 
-    /**
-     * @param float $writeTimeout
-     */
-    public function setWriteTimeout(float $writeTimeout)
+    public function setWriteTimeout(float $writeTimeout): void
     {
         $this->writeTimeout = $writeTimeout;
     }
 
-    /**
-     * @return float
-     */
     public function getWriteTimeout(): float
     {
         return $this->writeTimeout;
     }
 
-    /**
-     * @return int
-     */
     public function getHeartbeat(): int
     {
         return $this->heartbeat;
     }
 
-    /**
-     * @param int $heartbeat
-     */
-    public function setHeartbeat(int $heartbeat)
+    public function setHeartbeat(int $heartbeat): void
     {
         $this->heartbeat = $heartbeat;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getCACert()
+    public function getCACert(): ?string
     {
         return $this->cacert;
     }
 
-    /**
-     * @param string $cacert
-     */
-    public function setCACert(string $cacert)
+    public function setCACert(string $cacert): void
     {
         $this->cacert = $cacert;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getCert()
+    public function getCert(): ?string
     {
         return $this->cert;
     }
 
-    /**
-     * @param string $cert
-     */
-    public function setCert(string $cert)
+    public function setCert(string $cert): void
     {
         $this->cert = $cert;
     }
 
-    /**
-     * @return string|null
-     */
-    public function getKey()
+    public function getKey(): ?string
     {
         return $this->key;
     }
 
-    /**
-     * @param string $key
-     */
-    public function setKey(string $key)
+    public function setKey(string $key): void
     {
         $this->key = $key;
     }
 
-    /**
-     * @return bool|null
-     */
-    public function getVerify()
+    public function getVerify(): ?bool
     {
         return $this->verify;
     }
 
-    /**
-     * @param bool $verify
-     */
-    public function setVerify(bool $verify)
+    public function setVerify(bool $verify): void
     {
         $this->verify = $verify;
     }
 
-    /**
-     * @return array
-     */
-    public function toArray()
+    public function toArray(): array
     {
         $array = [];
         $transform = function ($letters) {

--- a/src/ConnectionOptions.php
+++ b/src/ConnectionOptions.php
@@ -182,11 +182,13 @@ class ConnectionOptions extends AbstractOptions
     public function toArray(): array
     {
         $array = [];
-        $transform = function ($letters) {
+
+        $transform = function ($letters): string {
             $letter = array_shift($letters);
 
             return '_' . strtolower($letter);
         };
+
         foreach ($this as $key => $value) {
             if ($key === '__strictMode__'
                 || null === $value

--- a/src/ConnectionOptions.php
+++ b/src/ConnectionOptions.php
@@ -44,7 +44,7 @@ class ConnectionOptions extends AbstractOptions
         $this->host = $host;
     }
 
-    public function getHost(): string
+    public function host(): string
     {
         return $this->host;
     }
@@ -54,7 +54,7 @@ class ConnectionOptions extends AbstractOptions
         $this->password = $password;
     }
 
-    public function getPassword(): string
+    public function password(): string
     {
         return $this->password;
     }
@@ -64,7 +64,7 @@ class ConnectionOptions extends AbstractOptions
         $this->persistent = $persistent;
     }
 
-    public function getPersistent(): bool
+    public function isPersistent(): bool
     {
         return $this->persistent;
     }
@@ -74,12 +74,12 @@ class ConnectionOptions extends AbstractOptions
         $this->port = $port;
     }
 
-    public function getPort(): int
+    public function port(): int
     {
         return $this->port;
     }
 
-    public function getConnectTimeout(): float
+    public function connectTimeout(): float
     {
         return $this->connectTimeout;
     }
@@ -94,7 +94,7 @@ class ConnectionOptions extends AbstractOptions
         $this->readTimeout = $readTimeout;
     }
 
-    public function getReadTimeout(): float
+    public function readTimeout(): float
     {
         return $this->readTimeout;
     }
@@ -104,7 +104,7 @@ class ConnectionOptions extends AbstractOptions
         $this->login = $login;
     }
 
-    public function getLogin(): string
+    public function login(): string
     {
         return $this->login;
     }
@@ -114,7 +114,7 @@ class ConnectionOptions extends AbstractOptions
         $this->vhost = $vhost;
     }
 
-    public function getVhost(): string
+    public function vhost(): string
     {
         return $this->vhost;
     }
@@ -124,12 +124,12 @@ class ConnectionOptions extends AbstractOptions
         $this->writeTimeout = $writeTimeout;
     }
 
-    public function getWriteTimeout(): float
+    public function writeTimeout(): float
     {
         return $this->writeTimeout;
     }
 
-    public function getHeartbeat(): int
+    public function heartbeat(): int
     {
         return $this->heartbeat;
     }
@@ -139,17 +139,17 @@ class ConnectionOptions extends AbstractOptions
         $this->heartbeat = $heartbeat;
     }
 
-    public function getCACert(): ?string
+    public function caCert(): ?string
     {
         return $this->cacert;
     }
 
-    public function setCACert(string $cacert): void
+    public function setCaCert(string $cacert): void
     {
         $this->cacert = $cacert;
     }
 
-    public function getCert(): ?string
+    public function cert(): ?string
     {
         return $this->cert;
     }
@@ -159,7 +159,7 @@ class ConnectionOptions extends AbstractOptions
         $this->cert = $cert;
     }
 
-    public function getKey(): ?string
+    public function key(): ?string
     {
         return $this->key;
     }
@@ -169,7 +169,7 @@ class ConnectionOptions extends AbstractOptions
         $this->key = $key;
     }
 
-    public function getVerify(): ?bool
+    public function verify(): ?bool
     {
         return $this->verify;
     }

--- a/src/ConnectionOptions.php
+++ b/src/ConnectionOptions.php
@@ -184,9 +184,9 @@ class ConnectionOptions extends AbstractOptions
         $array = [];
 
         $transform = function ($letters): string {
-            $letter = array_shift($letters);
+            $letter = \array_shift($letters);
 
-            return '_' . strtolower($letter);
+            return '_' . \strtolower($letter);
         };
 
         foreach ($this as $key => $value) {
@@ -195,7 +195,7 @@ class ConnectionOptions extends AbstractOptions
             ) {
                 continue;
             }
-            $normalizedKey = preg_replace_callback('/([A-Z])/', $transform, $key);
+            $normalizedKey = \preg_replace_callback('/([A-Z])/', $transform, $key);
             $array[$normalizedKey] = $value;
         }
 

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -25,20 +25,10 @@ namespace Humus\Amqp\Console\Command;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Command\Command;
 
-/**
- * Class AbstractCommand
- * @package Humus\Amqp\Console\Command
- */
 abstract class AbstractCommand extends Command
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
+    private ContainerInterface $container;
 
-    /**
-     * @return ContainerInterface
-     */
     public function getContainer(): ContainerInterface
     {
         if (null === $this->container) {

--- a/src/Console/Command/AbstractCommand.php
+++ b/src/Console/Command/AbstractCommand.php
@@ -27,7 +27,7 @@ use Symfony\Component\Console\Command\Command;
 
 abstract class AbstractCommand extends Command
 {
-    private ContainerInterface $container;
+    private ?ContainerInterface $container = null;
 
     public function getContainer(): ContainerInterface
     {

--- a/src/Console/Command/PublishMessageCommand.php
+++ b/src/Console/Command/PublishMessageCommand.php
@@ -25,10 +25,11 @@ namespace Humus\Amqp\Console\Command;
 use Humus\Amqp\Constants;
 use Humus\Amqp\Exception;
 use Humus\Amqp\Producer;
-use JsonException;
+use HumusAmqp\Util\Json;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
 
 class PublishMessageCommand extends AbstractCommand
 {
@@ -132,8 +133,8 @@ class PublishMessageCommand extends AbstractCommand
         $arguments = $input->getOption('arguments');
 
         try {
-            $arguments = \json_decode($arguments, true, 512, JSON_THROW_ON_ERROR);
-        } catch (JsonException $e) {
+            $arguments = Json::decode($arguments);
+        } catch (Throwable $e) {
             $output->writeln('Cannot decode arguments');
 
             return 1;

--- a/src/Console/Command/PublishMessageCommand.php
+++ b/src/Console/Command/PublishMessageCommand.php
@@ -25,6 +25,7 @@ namespace Humus\Amqp\Console\Command;
 use Humus\Amqp\Constants;
 use Humus\Amqp\Exception;
 use Humus\Amqp\Producer;
+use JsonException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -130,9 +131,9 @@ class PublishMessageCommand extends AbstractCommand
 
         $arguments = $input->getOption('arguments');
 
-        $arguments = json_decode($arguments, true);
-
-        if (json_last_error() !== 0) {
+        try {
+            $arguments = \json_decode($arguments, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
             $output->writeln('Cannot decode arguments');
 
             return 1;

--- a/src/Console/Command/PublishMessageCommand.php
+++ b/src/Console/Command/PublishMessageCommand.php
@@ -29,16 +29,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class PublishMessageCommand
- * @package Humus\Amqp\Console\Command
- */
 class PublishMessageCommand extends AbstractCommand
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('publish-message')
@@ -95,10 +88,7 @@ class PublishMessageCommand extends AbstractCommand
             ->setHelp('Purges a queue');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $producerName = $input->getOption('producer');
 
@@ -150,7 +140,7 @@ class PublishMessageCommand extends AbstractCommand
 
         $producer = $container->get($producerName);
 
-        /* @var Producer $producer */
+        assert($producer instanceof Producer);
 
         if ($transactional) {
             $producer->startTransaction();

--- a/src/Console/Command/PublishMessageCommand.php
+++ b/src/Console/Command/PublishMessageCommand.php
@@ -150,10 +150,10 @@ class PublishMessageCommand extends AbstractCommand
             $producer->confirmSelect();
 
             $producer->setConfirmCallback(
-                function (int $deliveryTag, bool $multiple = false) {
+                function (int $deliveryTag, bool $multiple = false): bool {
                     return false;
                 },
-                function (int $deliveryTag, bool $multiple, bool $requeue) {
+                function (int $deliveryTag, bool $multiple, bool $requeue): void {
                     throw new Exception\RuntimeException('Message nacked');
                 }
             );

--- a/src/Console/Command/PublishMessageCommand.php
+++ b/src/Console/Command/PublishMessageCommand.php
@@ -25,7 +25,7 @@ namespace Humus\Amqp\Console\Command;
 use Humus\Amqp\Constants;
 use Humus\Amqp\Exception;
 use Humus\Amqp\Producer;
-use HumusAmqp\Util\Json;
+use Humus\Amqp\Util\Json;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Console/Command/PurgeQueueCommand.php
+++ b/src/Console/Command/PurgeQueueCommand.php
@@ -28,16 +28,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class PurgeQueueCommand
- * @package Humus\Amqp\Console\Command
- */
 class PurgeQueueCommand extends AbstractCommand
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('purge-queue')
@@ -54,10 +47,7 @@ class PurgeQueueCommand extends AbstractCommand
             ->setHelp('Purges a queue');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $queueName = $input->getOption('name');
 
@@ -77,7 +67,7 @@ class PurgeQueueCommand extends AbstractCommand
             return 1;
         }
 
-        /* @var Queue $queue */
+        assert($queue instanceof Queue);
 
         $queue->purge();
 

--- a/src/Console/Command/SetupFabricCommand.php
+++ b/src/Console/Command/SetupFabricCommand.php
@@ -27,16 +27,9 @@ use Humus\Amqp\Container\QueueFactory;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class SetupFabricCommand
- * @package Humus\Amqp\Console\Command
- */
 class SetupFabricCommand extends AbstractCommand
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('setup-fabric')
@@ -45,10 +38,7 @@ class SetupFabricCommand extends AbstractCommand
             ->setHelp('Declares all AMQP exchanges and queues');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $config = $this->getContainer()->get('config');
 

--- a/src/Console/Command/ShowCommand.php
+++ b/src/Console/Command/ShowCommand.php
@@ -26,16 +26,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class ShowCommand
- * @package Humus\Amqp\Console\Command
- */
 class ShowCommand extends AbstractCommand
 {
-    /**
-     * @var array
-     */
-    protected $knownTypes = [
+    protected array $knownTypes = [
         'connections',
         'exchanges',
         'queues',
@@ -46,10 +39,7 @@ class ShowCommand extends AbstractCommand
         'all',
     ];
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('show')
@@ -72,10 +62,7 @@ class ShowCommand extends AbstractCommand
             ->setHelp('Show all AMQP ' . implode(', ', $this->knownTypes));
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $type = $input->getOption('type');
 
@@ -124,14 +111,7 @@ class ShowCommand extends AbstractCommand
         return 0;
     }
 
-    /**
-     * @param InputInterface $input
-     * @param OutputInterface $output
-     * @param array $config
-     * @param string $type
-     * @return void
-     */
-    protected function listType(InputInterface $input, OutputInterface $output, array $config, string $type)
+    protected function listType(InputInterface $input, OutputInterface $output, array $config, string $type): void
     {
         $type = substr($type, 0, -1);
 

--- a/src/Console/Command/ShowCommand.php
+++ b/src/Console/Command/ShowCommand.php
@@ -72,7 +72,7 @@ class ShowCommand extends AbstractCommand
             return 1;
         }
 
-        if (! in_array($type, $this->knownTypes)) {
+        if (! \in_array($type, $this->knownTypes)) {
             $output->writeln(
                 'Invalid type given, use one of ' . implode(', ', $this->knownTypes)
             );
@@ -122,7 +122,7 @@ class ShowCommand extends AbstractCommand
                 $output->writeln(ucfirst($type) . ': ' . $name);
 
                 if ($input->getOption('details')) {
-                    $output->writeln('Specs: ' . json_encode($spec, JSON_PRETTY_PRINT));
+                    $output->writeln('Specs: ' . \json_encode($spec, JSON_PRETTY_PRINT));
                     $output->writeln('');
                 }
             }

--- a/src/Console/Command/StartCallbackConsumerCommand.php
+++ b/src/Console/Command/StartCallbackConsumerCommand.php
@@ -27,16 +27,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class StartCallbackConsumerCommand
- * @package Humus\Amqp\Console\Command
- */
 class StartCallbackConsumerCommand extends AbstractCommand
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('consumer')
@@ -60,10 +53,7 @@ class StartCallbackConsumerCommand extends AbstractCommand
             ->setHelp('Start a consumer');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $consumerName = $input->getOption('name');
 
@@ -82,7 +72,8 @@ class StartCallbackConsumerCommand extends AbstractCommand
         }
 
         $callbackConsumer = $container->get($consumerName);
-        /* @var Consumer $callbackConsumer */
+
+        assert($callbackConsumer instanceof Consumer);
 
         $callbackConsumer->consume((int) $input->getOption('amount'));
 

--- a/src/Console/Command/StartJsonRpcServerCommand.php
+++ b/src/Console/Command/StartJsonRpcServerCommand.php
@@ -27,16 +27,9 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-/**
- * Class StartJsonRpcServerCommand
- * @package Humus\Amqp\Console\Command
- */
 class StartJsonRpcServerCommand extends AbstractCommand
 {
-    /**
-     * {@inheritdoc}
-     */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('json_rpc_server')
@@ -60,10 +53,7 @@ class StartJsonRpcServerCommand extends AbstractCommand
             ->setHelp('Start a JSON-RPC server');
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $serverName = $input->getOption('name');
 
@@ -82,7 +72,8 @@ class StartJsonRpcServerCommand extends AbstractCommand
         }
 
         $jsonRpcServer = $container->get($serverName);
-        /* @var Consumer $jsonRpcServer */
+
+        assert($jsonRpcServer instanceof Consumer);
 
         $jsonRpcServer->consume((int) $input->getOption('amount'));
 

--- a/src/Console/ConsoleRunner.php
+++ b/src/Console/ConsoleRunner.php
@@ -22,10 +22,10 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Console;
 
+use Humus\Amqp\Console\Command;
 use Humus\Amqp\Console\Helper\ContainerHelper;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 
 class ConsoleRunner

--- a/src/Console/ConsoleRunner.php
+++ b/src/Console/ConsoleRunner.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Console;
 
-use Humus\Amqp\Console\Command;
 use Humus\Amqp\Console\Helper\ContainerHelper;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;

--- a/src/Console/ConsoleRunner.php
+++ b/src/Console/ConsoleRunner.php
@@ -25,51 +25,31 @@ namespace Humus\Amqp\Console;
 use Humus\Amqp\Console\Helper\ContainerHelper;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\HelperSet;
 
-/**
- * Class ConsoleRunner
- * @package Humus\Amqp\Console
- */
 class ConsoleRunner
 {
-    /**
-     * Create a Symfony Console HelperSet
-     *
-     * @param ContainerInterface $container
-     * @return HelperSet
-     */
-    public static function createHelperSet(ContainerInterface $container)
+    public static function createHelperSet(ContainerInterface $container): HelperSet
     {
         return new HelperSet([
             'container' => new ContainerHelper($container),
         ]);
     }
 
-    /**
-     * Runs console with the given helperset.
-     *
-     * @param HelperSet  $helperSet
-     * @param \Symfony\Component\Console\Command\Command[] $commands
-     *
-     * @return void
-     */
-    public static function run(HelperSet $helperSet, array $commands = [])
+    public static function run(HelperSet $helperSet, array $commands = []): void
     {
         $cli = self::createApplication($helperSet, $commands);
         $cli->run();
     }
 
     /**
-     * Creates a console application with the given helperset and
-     * optional commands.
-     *
      * @param HelperSet $helperSet
-     * @param \Symfony\Component\Console\Command\Command[] $commands
+     * @param Command[] $commands
      *
      * @return Application
      */
-    public static function createApplication(HelperSet $helperSet, $commands = [])
+    public static function createApplication(HelperSet $helperSet, array $commands = []): Application
     {
         $cli = new Application('Humus Amqp Command Line Interface');
 
@@ -83,12 +63,7 @@ class ConsoleRunner
         return $cli;
     }
 
-    /**
-     * @param Application $cli
-     *
-     * @return void
-     */
-    public static function addCommands(Application $cli)
+    public static function addCommands(Application $cli): void
     {
         $cli->addCommands([
             new Command\PublishMessageCommand(),
@@ -100,10 +75,7 @@ class ConsoleRunner
         ]);
     }
 
-    /**
-     * @return void
-     */
-    public static function printCliConfigTemplate()
+    public static function printCliConfigTemplate(): void
     {
         echo <<<'HELP'
 You are missing a "humus-amqp-config.php" or "config/humus-amqp-config.php" file in your

--- a/src/Console/Helper/ContainerHelper.php
+++ b/src/Console/Helper/ContainerHelper.php
@@ -25,38 +25,21 @@ namespace Humus\Amqp\Console\Helper;
 use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\Helper;
 
-/**
- * Class ContainerHelper
- * @package Humus\Amqp\Console\Helper
- */
 class ContainerHelper extends Helper
 {
-    /**
-     * @var ContainerInterface
-     */
-    protected $container;
+    protected ContainerInterface $container;
 
-    /**
-     * ContainerHelper constructor.
-     * @param ContainerInterface $container
-     */
     public function __construct(ContainerInterface $container)
     {
         $this->container = $container;
     }
 
-    /**
-     * @return ContainerInterface
-     */
-    public function getContainer()
+    public function getContainer(): ContainerInterface
     {
         return $this->container;
     }
 
-    /**
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'container';
     }

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-/**
- * Class Constants
- * @package Humus\Amqp
- */
 abstract class Constants
 {
     /**

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -22,23 +22,9 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-/**
- * Interface Consumer
- * @package Humus\Amqp
- */
 interface Consumer
 {
-    /**
-     * Start consumer
-     *
-     * @param int $msgAmount
-     */
-    public function consume(int $msgAmount = 0);
+    public function consume(int $msgAmount = 0): void;
 
-    /**
-     * Shutdown consumer
-     *
-     * @return void
-     */
-    public function shutdown();
+    public function shutdown(): void;
 }

--- a/src/Container/CallbackConsumerFactory.php
+++ b/src/Container/CallbackConsumerFactory.php
@@ -32,18 +32,11 @@ use Interop\Config\RequiresMandatoryOptions;
 use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 
-/**
- * Class CallbackConsumerFactory
- * @package Humus\Amqp\Container
- */
 class CallbackConsumerFactory implements ProvidesDefaultOptions, RequiresConfigId, RequiresMandatoryOptions
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $consumerName;
+    private string $consumerName;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -60,7 +53,9 @@ class CallbackConsumerFactory implements ProvidesDefaultOptions, RequiresConfigI
      *
      * @param string $name
      * @param array $arguments
+     *
      * @return CallbackConsumer
+     *
      * @throws Exception\InvalidArgumentException
      */
     public static function __callStatic(string $name, array $arguments): CallbackConsumer
@@ -74,26 +69,19 @@ class CallbackConsumerFactory implements ProvidesDefaultOptions, RequiresConfigI
         return (new static($name))->__invoke($arguments[0]);
     }
 
-    /**
-     * CallbackConsumerFactory constructor.
-     * @param string $consumerName
-     */
     public function __construct(string $consumerName)
     {
         $this->consumerName = $consumerName;
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return CallbackConsumer
-     */
     public function __invoke(ContainerInterface $container): CallbackConsumer
     {
         $options = $this->options($container->get('config'), $this->consumerName);
 
         $queueName = $options['queue'];
         $queue = QueueFactory::$queueName($container);
-        /* @var Queue $queue */
+
+        assert($queue instanceof Queue);
 
         $channel = $queue->getChannel();
         $channel->qos($options['qos']['prefetch_size'], $options['qos']['prefetch_count']);
@@ -129,17 +117,11 @@ class CallbackConsumerFactory implements ProvidesDefaultOptions, RequiresConfigI
         );
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp', 'callback_consumer'];
     }
 
-    /**
-     * @return array
-     */
     public function defaultOptions(): array
     {
         return [
@@ -155,9 +137,6 @@ class CallbackConsumerFactory implements ProvidesDefaultOptions, RequiresConfigI
         ];
     }
 
-    /**
-     * @return array
-     */
     public function mandatoryOptions(): array
     {
         return [

--- a/src/Container/ConnectionFactory.php
+++ b/src/Container/ConnectionFactory.php
@@ -35,18 +35,11 @@ use Interop\Config\ProvidesDefaultOptions;
 use Interop\Config\RequiresConfigId;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class ConnectionFactory
- * @package Humus\Amqp\Container
- */
 final class ConnectionFactory implements ProvidesDefaultOptions, RequiresConfigId
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $connectionName;
+    private string $connectionName;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -63,7 +56,9 @@ final class ConnectionFactory implements ProvidesDefaultOptions, RequiresConfigI
      *
      * @param string $name
      * @param array $arguments
+     *
      * @return Connection
+     *
      * @throws Exception\InvalidArgumentException
      */
     public static function __callStatic(string $name, array $arguments): Connection
@@ -77,19 +72,11 @@ final class ConnectionFactory implements ProvidesDefaultOptions, RequiresConfigI
         return (new static($name))->__invoke($arguments[0]);
     }
 
-    /**
-     * ConnectionFactory constructor.
-     * @param string $connectionName
-     */
     public function __construct(string $connectionName)
     {
         $this->connectionName = $connectionName;
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return Connection
-     */
     public function __invoke(ContainerInterface $container): Connection
     {
         if (! $container->has(Driver::class)) {
@@ -143,17 +130,11 @@ final class ConnectionFactory implements ProvidesDefaultOptions, RequiresConfigI
         return $connection;
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp', 'connection'];
     }
 
-    /**
-     * @return array
-     */
     public function defaultOptions(): array
     {
         return [

--- a/src/Container/DriverFactory.php
+++ b/src/Container/DriverFactory.php
@@ -28,18 +28,10 @@ use Interop\Config\RequiresConfig;
 use Interop\Config\RequiresMandatoryOptions;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class DriverFactory
- * @package Humus\Amqp\Container
- */
 final class DriverFactory implements RequiresConfig, RequiresMandatoryOptions
 {
     use ConfigurationTrait;
 
-    /**
-     * @param ContainerInterface $container
-     * @return Driver
-     */
     public function __invoke(ContainerInterface $container): Driver
     {
         $options = $this->options($container->get('config'));
@@ -47,17 +39,11 @@ final class DriverFactory implements RequiresConfig, RequiresMandatoryOptions
         return Driver::get($options['driver']);
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp'];
     }
 
-    /**
-     * @return array
-     */
     public function mandatoryOptions(): array
     {
         return [

--- a/src/Container/ExchangeFactory.php
+++ b/src/Container/ExchangeFactory.php
@@ -80,7 +80,7 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
             $arguments[2] = false;
         }
 
-        if (! is_bool($arguments[2])) {
+        if (! \is_bool($arguments[2])) {
             throw new Exception\InvalidArgumentException('The third argument must be a boolean');
         }
 

--- a/src/Container/ExchangeFactory.php
+++ b/src/Container/ExchangeFactory.php
@@ -32,28 +32,13 @@ use Interop\Config\RequiresConfigId;
 use Interop\Config\RequiresMandatoryOptions;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class ExchangeFactory
- * @package Humus\Amqp\Container
- */
 final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId, RequiresMandatoryOptions
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $exchangeName;
-
-    /**
-     * @var Channel|null
-     */
-    private $channel;
-
-    /**
-     * @var bool
-     */
-    private $autoSetupFabric;
+    private string $exchangeName;
+    private ?Channel $channel;
+    private bool $autoSetupFabric;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -70,7 +55,9 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
      *
      * @param string $name
      * @param array $arguments
+     *
      * @return Exchange
+     *
      * @throws Exception\InvalidArgumentException
      */
     public static function __callStatic(string $name, array $arguments): Exchange
@@ -100,12 +87,6 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
         return (new static($name, $arguments[1], $arguments[2]))->__invoke($arguments[0]);
     }
 
-    /**
-     * QueueFactory constructor.
-     * @param string $exchangeName
-     * @param Channel|null $channel
-     * @param bool $autoSetupFabric
-     */
     public function __construct(string $exchangeName, Channel $channel = null, bool $autoSetupFabric = false)
     {
         $this->exchangeName = $exchangeName;
@@ -113,11 +94,6 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
         $this->autoSetupFabric = $autoSetupFabric;
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return Exchange
-     * @throws Exception\InvalidArgumentException
-     */
     public function __invoke(ContainerInterface $container): Exchange
     {
         $config = $container->get('config');
@@ -162,17 +138,11 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
         return $exchange;
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp', 'exchange'];
     }
 
-    /**
-     * @return array
-     */
     public function defaultOptions(): array
     {
         return [
@@ -188,9 +158,6 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
         ];
     }
 
-    /**
-     * return array
-     */
     public function mandatoryOptions(): array
     {
         return [
@@ -201,6 +168,7 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
 
     /**
      * @param array|ArrayAccess
+     *
      * @return int
      */
     private function getFlags($options): int
@@ -214,18 +182,12 @@ final class ExchangeFactory implements ProvidesDefaultOptions, RequiresConfigId,
         return $flags;
     }
 
-    /**
-     * @param Exchange $exchange
-     * @param string $exchangeName
-     * @param array $routingKeys
-     * @param array $bindArguments
-     */
     private function bindExchange(
         Exchange $exchange,
         string $exchangeName,
         array $routingKeys,
         array $bindArguments
-    ) {
+    ): void {
         if (empty($routingKeys)) {
             $exchange->bind($exchangeName, '', $bindArguments);
         } else {

--- a/src/Container/JsonRpcClientFactory.php
+++ b/src/Container/JsonRpcClientFactory.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace Humus\Amqp\Container;
 
 use Humus\Amqp\Exception;
-use Humus\Amqp\JsonRpc\Client;
 use Humus\Amqp\JsonRpc\JsonRpcClient;
 use Interop\Config\ConfigurationTrait;
 use Interop\Config\ProvidesDefaultOptions;

--- a/src/Container/JsonRpcClientFactory.php
+++ b/src/Container/JsonRpcClientFactory.php
@@ -86,7 +86,7 @@ final class JsonRpcClientFactory implements ProvidesDefaultOptions, RequiresConf
             $options['exchanges'] = iterator_to_array($options['exchanges']);
         }
 
-        if (! is_array($options['exchanges']) || empty($options['exchanges'])) {
+        if (! \is_array($options['exchanges']) || empty($options['exchanges'])) {
             throw new Exception\InvalidArgumentException(
                 'Option "exchanges" must be a not empty array or an instance of Traversable'
             );

--- a/src/Container/JsonRpcClientFactory.php
+++ b/src/Container/JsonRpcClientFactory.php
@@ -32,18 +32,11 @@ use Interop\Config\RequiresMandatoryOptions;
 use Psr\Container\ContainerInterface;
 use Traversable;
 
-/**
- * Class JsonRpcClientFactory
- * @package Humus\Amqp\Container
- */
 final class JsonRpcClientFactory implements ProvidesDefaultOptions, RequiresConfigId, RequiresMandatoryOptions
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $clientName;
+    private string $clientName;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -60,7 +53,9 @@ final class JsonRpcClientFactory implements ProvidesDefaultOptions, RequiresConf
      *
      * @param string $name
      * @param array $arguments
-     * @return Client
+     *
+     * @return JsonRpcClient
+     *
      * @throws Exception\InvalidArgumentException
      */
     public static function __callStatic(string $name, array $arguments): JsonRpcClient
@@ -74,19 +69,11 @@ final class JsonRpcClientFactory implements ProvidesDefaultOptions, RequiresConf
         return (new static($name))->__invoke($arguments[0]);
     }
 
-    /**
-     * JsonRpcClientFactory constructor.
-     * @param string $clientName
-     */
     public function __construct(string $clientName)
     {
         $this->clientName = $clientName;
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return JsonRpcClient
-     */
     public function __invoke(ContainerInterface $container): JsonRpcClient
     {
         $options = $this->options($container->get('config'), $this->clientName);
@@ -119,17 +106,11 @@ final class JsonRpcClientFactory implements ProvidesDefaultOptions, RequiresConf
         return new JsonRpcClient($queue, $exchanges, $options['wait_micros'], $options['app_id'], $errorFactory);
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp', 'json_rpc_client'];
     }
 
-    /**
-     * @return array
-     */
     public function defaultOptions(): array
     {
         return [
@@ -138,9 +119,6 @@ final class JsonRpcClientFactory implements ProvidesDefaultOptions, RequiresConf
         ];
     }
 
-    /**
-     * @return array
-     */
     public function mandatoryOptions(): array
     {
         return [

--- a/src/Container/JsonRpcServerFactory.php
+++ b/src/Container/JsonRpcServerFactory.php
@@ -31,18 +31,11 @@ use Interop\Config\RequiresMandatoryOptions;
 use Psr\Container\ContainerInterface;
 use Psr\Log\NullLogger;
 
-/**
- * Class JsonRpcServerFactory
- * @package Humus\Amqp\Container
- */
 final class JsonRpcServerFactory implements ProvidesDefaultOptions, RequiresConfigId, RequiresMandatoryOptions
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $serverName;
+    private string $serverName;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -59,7 +52,9 @@ final class JsonRpcServerFactory implements ProvidesDefaultOptions, RequiresConf
      *
      * @param string $name
      * @param array $arguments
+     *
      * @return JsonRpcServer
+     *
      * @throws Exception\InvalidArgumentException
      */
     public static function __callStatic(string $name, array $arguments): JsonRpcServer
@@ -73,19 +68,11 @@ final class JsonRpcServerFactory implements ProvidesDefaultOptions, RequiresConf
         return (new static($name))->__invoke($arguments[0]);
     }
 
-    /**
-     * JsonRpcClientFactory constructor.
-     * @param string $serverName
-     */
     public function __construct(string $serverName)
     {
         $this->serverName = $serverName;
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return JsonRpcServer
-     */
     public function __invoke(ContainerInterface $container): JsonRpcServer
     {
         $options = $this->options($container->get('config'), $this->serverName);
@@ -118,17 +105,11 @@ final class JsonRpcServerFactory implements ProvidesDefaultOptions, RequiresConf
         );
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp', 'json_rpc_server'];
     }
 
-    /**
-     * @return array
-     */
     public function defaultOptions(): array
     {
         return [
@@ -139,9 +120,6 @@ final class JsonRpcServerFactory implements ProvidesDefaultOptions, RequiresConf
         ];
     }
 
-    /**
-     * @return array
-     */
     public function mandatoryOptions(): array
     {
         return [

--- a/src/Container/ProducerFactory.php
+++ b/src/Container/ProducerFactory.php
@@ -32,18 +32,11 @@ use Interop\Config\RequiresConfigId;
 use Interop\Config\RequiresMandatoryOptions;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class ProducerFactory
- * @package Humus\Amqp\Container
- */
 final class ProducerFactory implements ProvidesDefaultOptions, RequiresConfigId, RequiresMandatoryOptions
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $producerName;
+    private string $producerName;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -60,7 +53,9 @@ final class ProducerFactory implements ProvidesDefaultOptions, RequiresConfigId,
      *
      * @param string $name
      * @param array $arguments
+     *
      * @return Producer
+     *
      * @throws Exception\InvalidArgumentException
      */
     public static function __callStatic(string $name, array $arguments): Producer
@@ -74,18 +69,11 @@ final class ProducerFactory implements ProvidesDefaultOptions, RequiresConfigId,
         return (new static($name))->__invoke($arguments[0]);
     }
 
-    /**
-     * @param string $producerName
-     */
     public function __construct(string $producerName)
     {
         $this->producerName = $producerName;
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return Producer
-     */
     public function __invoke(ContainerInterface $container): Producer
     {
         $options = $this->options($container->get('config'), $this->producerName);
@@ -107,17 +95,11 @@ final class ProducerFactory implements ProvidesDefaultOptions, RequiresConfigId,
         }
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp', 'producer'];
     }
 
-    /**
-     * @return array
-     */
     public function defaultOptions(): array
     {
         return [
@@ -127,9 +109,6 @@ final class ProducerFactory implements ProvidesDefaultOptions, RequiresConfigId,
         ];
     }
 
-    /**
-     * @return array
-     */
     public function mandatoryOptions(): array
     {
         return [

--- a/src/Container/QueueFactory.php
+++ b/src/Container/QueueFactory.php
@@ -25,7 +25,6 @@ namespace Humus\Amqp\Container;
 use Humus\Amqp\Channel;
 use Humus\Amqp\Constants;
 use Humus\Amqp\Exception;
-use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
 use Interop\Config\ConfigurationTrait;
 use Interop\Config\ProvidesDefaultOptions;

--- a/src/Container/QueueFactory.php
+++ b/src/Container/QueueFactory.php
@@ -84,7 +84,7 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
             $arguments[2] = false;
         }
 
-        if (! is_bool($arguments[2])) {
+        if (! \is_bool($arguments[2])) {
             throw new Exception\InvalidArgumentException(
                 sprintf('The third argument must be a boolean')
             );
@@ -133,7 +133,7 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
                 $exchanges = iterator_to_array($exchanges);
             }
 
-            if (! is_array($exchanges) || empty($exchanges)) {
+            if (! \is_array($exchanges) || empty($exchanges)) {
                 throw new Exception\InvalidArgumentException('Expected an array or traversable of exchanges');
             }
 

--- a/src/Container/QueueFactory.php
+++ b/src/Container/QueueFactory.php
@@ -33,28 +33,13 @@ use Interop\Config\RequiresConfigId;
 use Interop\Config\RequiresMandatoryOptions;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class QueueFactory
- * @package Humus\Amqp\Container
- */
 final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, RequiresMandatoryOptions
 {
     use ConfigurationTrait;
 
-    /**
-     * @var string
-     */
-    private $queueName;
-
-    /**
-     * @var Channel|null
-     */
-    private $channel;
-
-    /**
-     * @var bool
-     */
-    private $autoSetupFabric;
+    private string $queueName;
+    private ?Channel $channel;
+    private bool $autoSetupFabric;
 
     /**
      * Creates a new instance from a specified config, specifically meant to be used as static factory.
@@ -71,7 +56,9 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
      *
      * @param string $name
      * @param array $arguments
+     *
      * @return Queue
+     *
      * @throws Exception\ChannelException
      * @throws Exception\QueueException
      * @throws \Psr\Container\ContainerExceptionInterface
@@ -106,12 +93,6 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
         return (new static($name, $arguments[1], $arguments[2]))->__invoke($arguments[0]);
     }
 
-    /**
-     * QueueFactory constructor.
-     * @param string $queueName
-     * @param Channel|null $channel
-     * @param bool $autoSetupFabric
-     */
     public function __construct(string $queueName, Channel $channel = null, bool $autoSetupFabric = false)
     {
         $this->queueName = $queueName;
@@ -119,14 +100,6 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
         $this->autoSetupFabric = $autoSetupFabric;
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return Queue
-     * @throws Exception\ChannelException
-     * @throws Exception\QueueException
-     * @throws \Psr\Container\ContainerExceptionInterface
-     * @throws \Psr\Container\NotFoundExceptionInterface
-     */
     public function __invoke(ContainerInterface $container): Queue
     {
         $options = $this->options($container->get('config'), $this->queueName);
@@ -204,17 +177,11 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
         return $queue;
     }
 
-    /**
-     * @return array
-     */
     public function dimensions(): array
     {
         return ['humus', 'amqp', 'queue'];
     }
 
-    /**
-     * @return array
-     */
     public function defaultOptions(): array
     {
         return [
@@ -230,9 +197,6 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
         ];
     }
 
-    /**
-     * return array
-     */
     public function mandatoryOptions(): array
     {
         return [
@@ -243,6 +207,7 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
 
     /**
      * @param array|\ArrayAccess
+     *
      * @return int
      */
     private function getFlags($options): int
@@ -256,13 +221,7 @@ final class QueueFactory implements ProvidesDefaultOptions, RequiresConfigId, Re
         return $flags;
     }
 
-    /**
-     * @param Queue $queue
-     * @param string $exchange
-     * @param array $routingKeys
-     * @param array $bindArguments
-     */
-    private function bindQueue(Queue $queue, string $exchange, array $routingKeys, array $bindArguments)
+    private function bindQueue(Queue $queue, string $exchange, array $routingKeys, array $bindArguments): void
     {
         if (empty($routingKeys)) {
             $queue->bind($exchange, '', $bindArguments);

--- a/src/DeliveryResult.php
+++ b/src/DeliveryResult.php
@@ -26,9 +26,6 @@ use MabeEnum\Enum;
 use MabeEnum\EnumSerializableTrait;
 
 /**
- * Class DeliveryResult
- * @package Humus\Amqp
- *
  * @method static DeliveryResult MSG_ACK()
  * @method static DeliveryResult MSG_DEFER()
  * @method static DeliveryResult MSG_REJECT()

--- a/src/Driver/AmqpExtension/Channel.php
+++ b/src/Driver/AmqpExtension/Channel.php
@@ -129,6 +129,7 @@ final class Channel implements ChannelInterface
     public function setReturnCallback(callable $returnCallback = null): void
     {
         $innerCallback = null;
+
         if ($returnCallback) {
             $innerCallback = function (
                 int $replyCode,
@@ -137,7 +138,7 @@ final class Channel implements ChannelInterface
                 string $routingKey,
                 \AMQPBasicProperties $properties,
                 string $body
-            ) use ($returnCallback) {
+            ) use ($returnCallback): bool {
                 return $returnCallback($replyCode, $replyText, $exchange, $routingKey, new Envelope($properties), $body);
             };
         }

--- a/src/Driver/AmqpExtension/Channel.php
+++ b/src/Driver/AmqpExtension/Channel.php
@@ -22,161 +22,100 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Driver\AmqpExtension;
 
+use AMQPChannel;
 use Humus\Amqp\Channel as ChannelInterface;
 use Humus\Amqp\Connection as ConnectionInterface;
 use Humus\Amqp\Exception\ChannelException;
 use Humus\Amqp\Exchange as ExchangeInterface;
 use Humus\Amqp\Queue as QueueInterface;
 
-/**
- * Class Channel
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 final class Channel implements ChannelInterface
 {
-    /**
-     * @var Connection
-     */
-    private $connection;
+    private Connection $connection;
+    private AMQPChannel $channel;
 
-    /**
-     * @var \AMQPChannel
-     */
-    private $channel;
-
-    /**
-     * Create an instance of an AMQPChannel object.
-     */
     public function __construct(Connection $amqpConnection)
     {
         $this->connection = $amqpConnection;
-        $this->channel = new \AMQPChannel($amqpConnection->getResource());
+        $this->channel = new AMQPChannel($amqpConnection->getResource());
     }
 
-    /**
-     * @return \AMQPChannel
-     */
     public function getResource(): \AMQPChannel
     {
         return $this->channel;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isConnected(): bool
     {
         return $this->channel->isConnected();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getChannelId(): int
     {
         return $this->channel->getChannelId();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPrefetchSize(int $size)
+    public function setPrefetchSize(int $size): void
     {
         $this->channel->setPrefetchSize($size);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPrefetchSize(): int
     {
         return $this->channel->getPrefetchSize();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPrefetchCount(int $count)
+    public function setPrefetchCount(int $count): void
     {
         $this->channel->setPrefetchCount($count);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPrefetchCount(): int
     {
         return $this->channel->getPrefetchCount();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function qos(int $size, int $count)
+    public function qos(int $size, int $count): void
     {
         $this->channel->qos($size, $count);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function startTransaction()
+    public function startTransaction(): void
     {
         $this->channel->startTransaction();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->channel->commitTransaction();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->channel->rollbackTransaction();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConnection(): ConnectionInterface
     {
         return $this->connection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function basicRecover(bool $requeue = true)
+    public function basicRecover(bool $requeue = true): void
     {
         $this->channel->basicRecover($requeue);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function confirmSelect()
+    public function confirmSelect(): void
     {
         $this->channel->confirmSelect();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null)
+    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null): void
     {
         $this->channel->setConfirmCallback($ackCallback, $nackCallback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function waitForConfirm(float $timeout = 0.0)
+    public function waitForConfirm(float $timeout = 0.0): void
     {
         try {
             $this->channel->waitForConfirm($timeout);
@@ -187,10 +126,7 @@ final class Channel implements ChannelInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setReturnCallback(callable $returnCallback = null)
+    public function setReturnCallback(callable $returnCallback = null): void
     {
         $innerCallback = null;
         if ($returnCallback) {
@@ -209,10 +145,7 @@ final class Channel implements ChannelInterface
         $this->channel->setReturnCallback($innerCallback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function waitForBasicReturn(float $timeout = 0.0)
+    public function waitForBasicReturn(float $timeout = 0.0): void
     {
         try {
             $this->channel->waitForBasicReturn($timeout);
@@ -223,17 +156,11 @@ final class Channel implements ChannelInterface
         }
     }
 
-    /**
-     * @return ExchangeInterface
-     */
     public function newExchange(): ExchangeInterface
     {
         return new Exchange($this);
     }
 
-    /**
-     * @return QueueInterface
-     */
     public function newQueue(): QueueInterface
     {
         return new Queue($this);

--- a/src/Driver/AmqpExtension/Connection.php
+++ b/src/Driver/AmqpExtension/Connection.php
@@ -26,7 +26,6 @@ use AMQPConnection;
 use Humus\Amqp\Channel as ChannelInterface;
 use Humus\Amqp\Connection as ConnectionInterface;
 use Humus\Amqp\ConnectionOptions;
-use Humus\Amqp\Exception\ConnectionException;
 use Humus\Amqp\Exception\InvalidArgumentException;
 use Traversable;
 

--- a/src/Driver/AmqpExtension/Connection.php
+++ b/src/Driver/AmqpExtension/Connection.php
@@ -79,13 +79,13 @@ final class Connection implements ConnectionInterface
         }
     }
 
-    public function reconnect(): bool
+    public function reconnect(): void
     {
         if ($this->options->getPersistent()) {
-            return $this->connection->preconnect();
+            $this->connection->preconnect();
         }
 
-        return $this->connection->reconnect();
+        $this->connection->reconnect();
     }
 
     public function getOptions(): ConnectionOptions

--- a/src/Driver/AmqpExtension/Connection.php
+++ b/src/Driver/AmqpExtension/Connection.php
@@ -26,6 +26,7 @@ use AMQPConnection;
 use Humus\Amqp\Channel as ChannelInterface;
 use Humus\Amqp\Connection as ConnectionInterface;
 use Humus\Amqp\ConnectionOptions;
+use Humus\Amqp\Exception\ConnectionException;
 use Humus\Amqp\Exception\InvalidArgumentException;
 use Traversable;
 
@@ -43,7 +44,7 @@ final class Connection implements ConnectionInterface
             $options = new ConnectionOptions($options);
         }
 
-        if (true === $options->getVerify() && null === $options->getCACert()) {
+        if (true === $options->verify() && null === $options->caCert()) {
             throw new InvalidArgumentException('CA cert not set, so it can\'t be verified.');
         }
 
@@ -63,7 +64,7 @@ final class Connection implements ConnectionInterface
 
     public function connect(): void
     {
-        if ($this->options->getPersistent()) {
+        if ($this->options->isPersistent()) {
             $this->connection->pconnect();
         } else {
             $this->connection->connect();
@@ -72,7 +73,7 @@ final class Connection implements ConnectionInterface
 
     public function disconnect(): void
     {
-        if ($this->options->getPersistent()) {
+        if ($this->options->isPersistent()) {
             $this->connection->pdisconnect();
         } else {
             $this->connection->disconnect();
@@ -81,11 +82,11 @@ final class Connection implements ConnectionInterface
 
     public function reconnect(): void
     {
-        if ($this->options->getPersistent()) {
+        if ($this->options->isPersistent()) {
             $this->connection->preconnect();
+        } else {
+            $this->connection->reconnect();
         }
-
-        $this->connection->reconnect();
     }
 
     public function getOptions(): ConnectionOptions

--- a/src/Driver/AmqpExtension/Connection.php
+++ b/src/Driver/AmqpExtension/Connection.php
@@ -22,30 +22,19 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Driver\AmqpExtension;
 
+use AMQPConnection;
 use Humus\Amqp\Channel as ChannelInterface;
 use Humus\Amqp\Connection as ConnectionInterface;
 use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Exception\InvalidArgumentException;
 use Traversable;
 
-/**
- * Class Connection
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 final class Connection implements ConnectionInterface
 {
-    /**
-     * @var \AMQPConnection
-     */
-    private $connection;
+    private AMQPConnection $connection;
+    private ConnectionOptions $options;
 
     /**
-     * @var ConnectionOptions
-     */
-    private $options;
-
-    /**
-     * Connection constructor.
      * @param ConnectionOptions|array|Traversable $options
      */
     public function __construct($options)
@@ -59,29 +48,20 @@ final class Connection implements ConnectionInterface
         }
 
         $this->options = $options;
-        $this->connection = new \AMQPConnection($options->toArray());
+        $this->connection = new AMQPConnection($options->toArray());
     }
 
-    /**
-     * @return \AMQPConnection
-     */
-    public function getResource(): \AMQPConnection
+    public function getResource(): AMQPConnection
     {
         return $this->connection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isConnected(): bool
     {
         return $this->connection->isConnected();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function connect()
+    public function connect(): void
     {
         if ($this->options->getPersistent()) {
             $this->connection->pconnect();
@@ -90,10 +70,7 @@ final class Connection implements ConnectionInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function disconnect()
+    public function disconnect(): void
     {
         if ($this->options->getPersistent()) {
             $this->connection->pdisconnect();
@@ -102,9 +79,6 @@ final class Connection implements ConnectionInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function reconnect(): bool
     {
         if ($this->options->getPersistent()) {
@@ -114,17 +88,11 @@ final class Connection implements ConnectionInterface
         return $this->connection->reconnect();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getOptions(): ConnectionOptions
     {
         return $this->options;
     }
 
-    /**
-     * @return ChannelInterface
-     */
     public function newChannel(): ChannelInterface
     {
         return new Channel($this);

--- a/src/Driver/AmqpExtension/Envelope.php
+++ b/src/Driver/AmqpExtension/Envelope.php
@@ -126,6 +126,10 @@ final class Envelope implements EnvelopeInterface
 
     public function getHeader(string $header): ?string
     {
+        if (! $this->hasHeader($header)) {
+            return null;
+        }
+
         return $this->envelope->getHeader($header);
     }
 

--- a/src/Driver/AmqpExtension/Envelope.php
+++ b/src/Driver/AmqpExtension/Envelope.php
@@ -22,183 +22,113 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Driver\AmqpExtension;
 
+use AMQPBasicProperties;
 use Humus\Amqp\Envelope as EnvelopeInterface;
 
-/**
- * Class Envelope
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 final class Envelope implements EnvelopeInterface
 {
-    /**
-     * @var \AMQPBasicProperties
-     */
-    private $envelope;
+    private AMQPBasicProperties $envelope;
 
-    /**
-     * Envelope constructor.
-     * @param \AMQPBasicProperties $envelope
-     */
-    public function __construct(\AMQPBasicProperties $envelope)
+    public function __construct(AMQPBasicProperties $envelope)
     {
         $this->envelope = $envelope;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBody(): string
     {
         return (string) $this->envelope->getBody();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRoutingKey(): string
     {
         return $this->envelope->getRoutingKey();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getDeliveryTag(): int
     {
         return $this->envelope->getDeliveryTag();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getDeliveryMode(): int
     {
         return $this->envelope->getDeliveryMode();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getExchangeName(): string
     {
         return $this->envelope->getExchangeName();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isRedelivery(): bool
     {
         return $this->envelope->isRedelivery();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getContentType(): string
     {
         return $this->envelope->getContentType();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getContentEncoding(): string
     {
         return $this->envelope->getContentEncoding();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getType(): string
     {
         return $this->envelope->getType();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTimestamp(): int
     {
-        return $this->envelope->getTimeStamp();
+        return (int) $this->envelope->getTimeStamp();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         return $this->envelope->getPriority();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getExpiration(): int
     {
         return (int) $this->envelope->getExpiration();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getUserId(): string
     {
         return $this->envelope->getUserId();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAppId(): string
     {
         return $this->envelope->getAppId();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getMessageId(): string
     {
         return $this->envelope->getMessageId();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getReplyTo(): string
     {
         return $this->envelope->getReplyTo();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getCorrelationId(): string
     {
         return $this->envelope->getCorrelationId();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getHeaders(): array
     {
         return $this->envelope->getHeaders();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeader(string $header)
+    public function getHeader(string $header): ?string
     {
         return $this->envelope->getHeader($header);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasHeader(string $header): bool
     {
         return $this->envelope->hasHeader($header);

--- a/src/Driver/AmqpExtension/Exchange.php
+++ b/src/Driver/AmqpExtension/Exchange.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Driver\AmqpExtension;
 
+use AMQPExchange;
 use Humus\Amqp\Channel as ChannelInterface;
 use Humus\Amqp\Connection as ConnectionInterface;
 use Humus\Amqp\Constants;
@@ -33,74 +34,41 @@ use Humus\Amqp\Exchange as ExchangeInterface;
  */
 final class Exchange implements ExchangeInterface
 {
-    /**
-     * @var Channel
-     */
-    private $channel;
+    private Channel $channel;
+    private AMQPExchange $exchange;
 
-    /**
-     * @var \AMQPExchange
-     */
-    private $exchange;
-
-    /**
-     * Create an instance of AMQPExchange.
-     *
-     * Returns a new instance of an AMQPExchange object, associated with the
-     * given Channel object.
-     *
-     * @param Channel $channel A valid Channel object, connected to a broker.
-     */
     public function __construct(Channel $channel)
     {
         $this->channel = $channel;
-        $this->exchange = new \AMQPExchange($channel->getResource());
+        $this->exchange = new AMQPExchange($channel->getResource());
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): string
     {
         return $this->exchange->getName() ?: '';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setName(string $exchangeName)
+    public function setName(string $exchangeName): void
     {
         $this->exchange->setName($exchangeName);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getType(): string
     {
         return $this->exchange->getType() ?: '';
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setType(string $exchangeType)
+    public function setType(string $exchangeType): void
     {
         $this->exchange->setType($exchangeType);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFlags(): int
     {
         return $this->exchange->getFlags();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setFlags(int $flags)
+    public function setFlags(int $flags): void
     {
         $this->exchange->setFlags($flags);
     }
@@ -113,85 +81,55 @@ final class Exchange implements ExchangeInterface
         return $this->exchange->getArgument($key);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getArguments(): array
     {
         return $this->exchange->getArguments();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setArgument(string $key, $value)
+    public function setArgument(string $key, $value): void
     {
         $this->exchange->setArgument($key, $value);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setArguments(array $arguments)
+    public function setArguments(array $arguments): void
     {
         $this->exchange->setArguments($arguments);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function declareExchange()
+    public function declareExchange(): void
     {
         $this->exchange->declareExchange();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function delete(string $exchangeName = '', int $flags = Constants::AMQP_NOPARAM)
+    public function delete(string $exchangeName = '', int $flags = Constants::AMQP_NOPARAM): void
     {
         $this->exchange->delete($exchangeName, $flags);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function bind(string $exchangeName, string $routingKey = '', array $arguments = [])
+    public function bind(string $exchangeName, string $routingKey = '', array $arguments = []): void
     {
         $this->exchange->bind($exchangeName, $routingKey, $arguments);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = [])
+    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = []): void
     {
         $this->exchange->unbind($exchangeName, $routingKey, $arguments);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function publish(
         string $message,
         string $routingKey = '',
         int $flags = Constants::AMQP_NOPARAM,
         array $attributes = []
-    ) {
+    ): void {
         $this->exchange->publish($message, $routingKey, $flags, $attributes);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getChannel(): ChannelInterface
     {
         return $this->channel;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConnection(): ConnectionInterface
     {
         return $this->channel->getConnection();

--- a/src/Driver/AmqpExtension/Queue.php
+++ b/src/Driver/AmqpExtension/Queue.php
@@ -119,7 +119,7 @@ final class Queue implements AmqpQueueInterface
     public function consume(?callable $callback = null, int $flags = Constants::AMQP_NOPARAM, string $consumerTag = ''): void
     {
         if (null !== $callback) {
-            $innerCallback = function (\AMQPEnvelope $envelope, \AMQPQueue $queue) use ($callback) {
+            $innerCallback = function (\AMQPEnvelope $envelope, \AMQPQueue $queue) use ($callback): bool {
                 $envelope = new Envelope($envelope);
 
                 return $callback($envelope, $this);

--- a/src/Driver/AmqpExtension/Queue.php
+++ b/src/Driver/AmqpExtension/Queue.php
@@ -109,15 +109,11 @@ final class Queue implements AmqpQueueInterface
             throw new ChannelException($e->getMessage());
         }
 
-        if (false === $envelope) {
-            return null;
-        }
-
         if ($envelope instanceof \AMQPEnvelope) {
-            $envelope = new Envelope($envelope);
+            return new Envelope($envelope);
         }
 
-        return $envelope;
+        return null;
     }
 
     public function consume(?callable $callback = null, int $flags = Constants::AMQP_NOPARAM, string $consumerTag = ''): void

--- a/src/Driver/Driver.php
+++ b/src/Driver/Driver.php
@@ -26,9 +26,6 @@ use MabeEnum\Enum;
 use MabeEnum\EnumSerializableTrait;
 
 /**
- * Class Driver
- * @package Humus\Amqp\Driver
- *
  * @method static Driver AMQP_EXTENSION()
  * @method static Driver PHP_AMQP_LIB()
  */

--- a/src/Driver/PhpAmqpLib/AbstractConnection.php
+++ b/src/Driver/PhpAmqpLib/AbstractConnection.php
@@ -53,11 +53,9 @@ abstract class AbstractConnection implements ConnectionInterface
         throw new BadMethodCallException();
     }
 
-    public function reconnect(): bool
+    public function reconnect(): void
     {
         $this->connection->reconnect();
-
-        return $this->isConnected();
     }
 
     public function getOptions(): ConnectionOptions

--- a/src/Driver/PhpAmqpLib/AbstractConnection.php
+++ b/src/Driver/PhpAmqpLib/AbstractConnection.php
@@ -28,57 +28,31 @@ use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Exception\BadMethodCallException;
 use PhpAmqpLib\Connection\AbstractConnection as PhpAmqplibAbstractConnection;
 
-/**
- * Class AbstractConnection
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 abstract class AbstractConnection implements ConnectionInterface
 {
-    /**
-     * @var PhpAmqplibAbstractConnection
-     */
-    protected $connection;
+    protected PhpAmqplibAbstractConnection $connection;
+    protected ConnectionOptions $options;
 
-    /**
-     * @var ConnectionOptions
-     */
-    protected $options;
-
-    /**
-     * @return PhpAmqplibAbstractConnection
-     */
     public function getResource(): PhpAmqplibAbstractConnection
     {
         return $this->connection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isConnected(): bool
     {
         return $this->connection->isConnected();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function connect()
+    public function connect(): void
     {
         throw new BadMethodCallException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function disconnect()
+    public function disconnect(): void
     {
         throw new BadMethodCallException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function reconnect(): bool
     {
         $this->connection->reconnect();
@@ -86,17 +60,11 @@ abstract class AbstractConnection implements ConnectionInterface
         return $this->isConnected();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getOptions(): ConnectionOptions
     {
         return $this->options;
     }
 
-    /**
-     * @return ChannelInterface
-     */
     public function newChannel(): ChannelInterface
     {
         $channel = new Channel($this, $this->getResource()->channel());

--- a/src/Driver/PhpAmqpLib/Channel.php
+++ b/src/Driver/PhpAmqpLib/Channel.php
@@ -130,14 +130,14 @@ final class Channel implements ChannelInterface
 
     public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null): void
     {
-        if (is_callable($ackCallback)) {
+        if (\is_callable($ackCallback)) {
             $innerAckCallback = function (AMQPMessage $message) use ($ackCallback): bool {
                 return $ackCallback((int) $message->get('delivery_tag'), false);
             };
             $this->channel->set_ack_handler($innerAckCallback);
         }
 
-        if (is_callable($nackCallback)) {
+        if (\is_callable($nackCallback)) {
             $innerNackCallback = function (AMQPMessage $message) use ($ackCallback): bool {
                 return $ackCallback((int) $message->get('delivery_tag'), false, false);
             };

--- a/src/Driver/PhpAmqpLib/Channel.php
+++ b/src/Driver/PhpAmqpLib/Channel.php
@@ -43,13 +43,13 @@ final class Channel implements ChannelInterface
     {
         $this->connection = $connection;
         $this->channel = $channel;
-        $this->channel->set_ack_handler(function () {
+        $this->channel->set_ack_handler(function (): void {
             trigger_error('Unhandled basic.ack method from server received.');
         });
-        $this->channel->set_nack_handler(function () {
+        $this->channel->set_nack_handler(function (): void {
             trigger_error('Unhandled basic.nack method from server received.');
         });
-        $this->channel->set_return_listener(function () {
+        $this->channel->set_return_listener(function (): void {
             trigger_error('Unhandled basic.return method from server received.');
         });
     }
@@ -131,14 +131,14 @@ final class Channel implements ChannelInterface
     public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null): void
     {
         if (is_callable($ackCallback)) {
-            $innerAckCallback = function (AMQPMessage $message) use ($ackCallback) {
+            $innerAckCallback = function (AMQPMessage $message) use ($ackCallback): bool {
                 return $ackCallback((int) $message->get('delivery_tag'), false);
             };
             $this->channel->set_ack_handler($innerAckCallback);
         }
 
         if (is_callable($nackCallback)) {
-            $innerNackCallback = function (AMQPMessage $message) use ($ackCallback) {
+            $innerNackCallback = function (AMQPMessage $message) use ($ackCallback): bool {
                 return $ackCallback((int) $message->get('delivery_tag'), false, false);
             };
             $this->channel->set_nack_handler($innerNackCallback);
@@ -174,7 +174,7 @@ final class Channel implements ChannelInterface
             $exchange,
             $routingKey,
             $message
-        ) use ($returnCallback) {
+        ) use ($returnCallback): bool {
             $envelope = new Envelope($message);
 
             return $returnCallback($replyCode, $replyText, $exchange, $routingKey, $envelope, $envelope->getBody());

--- a/src/Driver/PhpAmqpLib/Channel.php
+++ b/src/Driver/PhpAmqpLib/Channel.php
@@ -32,38 +32,13 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Exception\AMQPExceptionInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 
-/**
- * Class Channel
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 final class Channel implements ChannelInterface
 {
-    /**
-     * @var AbstractConnection
-     */
-    private $connection;
+    private AbstractConnection $connection;
+    private AMQPChannel $channel;
+    private int $prefetchCount;
+    private int $prefetchSize;
 
-    /**
-     * @var AMQPChannel
-     */
-    private $channel;
-
-    /**
-     * @var int
-     */
-    private $prefetchCount;
-
-    /**
-     * @var int
-     */
-    private $prefechSize;
-
-    /**
-     * Create an instance of an AMQPChannel object.
-     *
-     * @param AbstractConnection $connection  An instance of AbstractConnection with an active connection to a broker.
-     * @param AMQPChannel $channel
-     */
     public function __construct(AbstractConnection $connection, AMQPChannel $channel)
     {
         $this->connection = $connection;
@@ -79,126 +54,81 @@ final class Channel implements ChannelInterface
         });
     }
 
-    /**
-     * @return AMQPChannel
-     */
     public function getResource(): AMQPChannel
     {
         return $this->channel;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isConnected(): bool
     {
         throw new BadMethodCallException();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getChannelId(): int
     {
         return (int) $this->channel->getChannelId();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPrefetchSize(int $size)
+    public function setPrefetchSize(int $size): void
     {
         $this->channel->basic_qos($size, 0, false);
-        $this->prefechSize = $size;
+        $this->prefetchSize = $size;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPrefetchSize(): int
     {
-        return $this->prefechSize;
+        return $this->prefetchSize;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setPrefetchCount(int $count)
+    public function setPrefetchCount(int $count): void
     {
         $this->channel->basic_qos(0, $count, false);
         $this->prefetchCount = $count;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPrefetchCount(): int
     {
         return $this->prefetchCount;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function qos(int $size, int $count)
+    public function qos(int $size, int $count): void
     {
         $this->channel->basic_qos($size, $count, false);
         $this->prefechSize = $size;
         $this->prefetchCount = $count;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function startTransaction()
+    public function startTransaction(): void
     {
         $this->channel->tx_select();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function commitTransaction()
+    public function commitTransaction(): void
     {
         $this->channel->tx_commit();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function rollbackTransaction()
+    public function rollbackTransaction(): void
     {
         $this->channel->tx_rollback();
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConnection(): ConnectionInterface
     {
         return $this->connection;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function basicRecover(bool $requeue = true)
+    public function basicRecover(bool $requeue = true): void
     {
         $this->channel->basic_recover($requeue);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function confirmSelect()
+    public function confirmSelect(): void
     {
         $this->channel->confirm_select();
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null)
+    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null): void
     {
         if (is_callable($ackCallback)) {
             $innerAckCallback = function (AMQPMessage $message) use ($ackCallback) {
@@ -215,10 +145,7 @@ final class Channel implements ChannelInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function waitForConfirm(float $timeout = 0.0)
+    public function waitForConfirm(float $timeout = 0.0): void
     {
         if ($timeout < 0) {
             throw new ChannelException('Timeout must be greater than or equal to zero.');
@@ -235,10 +162,7 @@ final class Channel implements ChannelInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setReturnCallback(callable $returnCallback = null)
+    public function setReturnCallback(callable $returnCallback = null): void
     {
         if (! $returnCallback) {
             return;
@@ -259,10 +183,7 @@ final class Channel implements ChannelInterface
         $this->channel->set_return_listener($innerCallback);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function waitForBasicReturn(float $timeout = 0.0)
+    public function waitForBasicReturn(float $timeout = 0.0): void
     {
         try {
             $this->channel->wait(null, false, $timeout);
@@ -271,17 +192,11 @@ final class Channel implements ChannelInterface
         }
     }
 
-    /**
-     * @return ExchangeInterface
-     */
     public function newExchange(): ExchangeInterface
     {
         return new Exchange($this);
     }
 
-    /**
-     * @return QueueInterface
-     */
     public function newQueue(): QueueInterface
     {
         return new Queue($this);

--- a/src/Driver/PhpAmqpLib/Envelope.php
+++ b/src/Driver/PhpAmqpLib/Envelope.php
@@ -26,173 +26,108 @@ use Humus\Amqp\Envelope as EnvelopeInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
-/**
- * Class Envelope
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 final class Envelope implements EnvelopeInterface
 {
-    /**
-     * @var AMQPMessage
-     */
-    private $envelope;
+    private AMQPMessage $envelope;
 
-    /**
-     * Envelope constructor.
-     * @param AMQPMessage $message
-     */
     public function __construct(AMQPMessage $message)
     {
         $this->envelope = $message;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getBody(): string
     {
         return $this->envelope->body;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getRoutingKey(): string
     {
-        return $this->envelope->get('routing_key');
+        return (string) $this->envelope->get('routing_key');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getDeliveryTag(): int
     {
         return (int) $this->envelope->get('delivery_tag');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getDeliveryMode(): int
     {
         if ($this->envelope->has('delivery_mode')) {
-            return $this->envelope->get('delivery_mode');
+            return (int) $this->envelope->get('delivery_mode');
         }
 
         return 1;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getExchangeName(): string
     {
         return $this->getFromEnvelope('exchange');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function isRedelivery(): bool
     {
-        return $this->envelope->get('redelivered');
+        return (bool) $this->envelope->get('redelivered');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getContentType(): string
     {
         return $this->getFromEnvelope('content_type');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getContentEncoding(): string
     {
         return $this->getFromEnvelope('content_encoding');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getType(): string
     {
         return $this->getFromEnvelope('type');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getTimestamp(): int
     {
         return (int) $this->getFromEnvelope('timestamp');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getPriority(): int
     {
         if ($this->envelope->has('priority')) {
-            return $this->envelope->get('priority');
+            return (int) $this->envelope->get('priority');
         }
 
         return 0;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getExpiration(): int
     {
         return (int) $this->getFromEnvelope('expiration');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getUserId(): string
     {
         return $this->getFromEnvelope('user_id');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getAppId(): string
     {
         return $this->getFromEnvelope('app_id');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getMessageId(): string
     {
         return $this->getFromEnvelope('message_id');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getReplyTo(): string
     {
         return $this->getFromEnvelope('reply_to');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getCorrelationId(): string
     {
         return $this->getFromEnvelope('correlation_id');
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getHeaders(): array
     {
         try {
@@ -212,19 +147,13 @@ final class Envelope implements EnvelopeInterface
         return [];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getHeader(string $header)
+    public function getHeader(string $header): ?string
     {
         $headers = $this->getHeaders();
 
-        return $headers[$header] ?? false;
+        return $headers[$header] ?? null;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function hasHeader(string $header): bool
     {
         $headers = $this->getHeaders();
@@ -232,10 +161,6 @@ final class Envelope implements EnvelopeInterface
         return isset($headers[$header]);
     }
 
-    /**
-     * @param string $name
-     * @return string
-     */
     private function getFromEnvelope(string $name): string
     {
         if ($this->envelope->has($name)) {

--- a/src/Driver/PhpAmqpLib/Exchange.php
+++ b/src/Driver/PhpAmqpLib/Exchange.php
@@ -154,7 +154,7 @@ final class Exchange implements ExchangeInterface
         string $routingKey = '',
         int $flags = Constants::AMQP_NOPARAM, array $attributes = []
     ): void {
-        $attributes['user_id'] = $this->getConnection()->getOptions()->getLogin();
+        $attributes['user_id'] = $this->getConnection()->getOptions()->login();
         $message = new AMQPMessage($message, $attributes);
 
         if (isset($attributes['headers'])) {

--- a/src/Driver/PhpAmqpLib/Exchange.php
+++ b/src/Driver/PhpAmqpLib/Exchange.php
@@ -29,94 +29,45 @@ use Humus\Amqp\Exchange as ExchangeInterface;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
-/**
- * Class Exchange
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 final class Exchange implements ExchangeInterface
 {
-    /**
-     * @var Channel
-     */
-    private $channel;
+    private Channel $channel;
+    private string $name = '';
+    private string $type = '';
+    private int $flags = Constants::AMQP_NOPARAM;
+    private array $arguments = [];
 
-    /**
-     * @var string
-     */
-    private $name = '';
-
-    /**
-     * @var string
-     */
-    private $type = '';
-
-    /**
-     * @var int
-     */
-    private $flags = Constants::AMQP_NOPARAM;
-
-    /**
-     * @var array
-     */
-    private $arguments = [];
-
-    /**
-     * Create an instance of AMQPExchange.
-     *
-     * Returns a new instance of an AMQPExchange object, associated with the
-     * given Channel object.
-     *
-     * @param Channel $channel A valid Channel object, connected to a broker.
-     */
     public function __construct(Channel $channel)
     {
         $this->channel = $channel;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setName(string $exchangeName)
+    public function setName(string $exchangeName): void
     {
         $this->name = $exchangeName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getType(): string
     {
         return $this->type;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setType(string $exchangeType)
+    public function setType(string $exchangeType): void
     {
         $this->type = $exchangeType;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFlags(): int
     {
         return $this->flags;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setFlags(int $flags)
+    public function setFlags(int $flags): void
     {
         $this->flags = (int) $flags;
     }
@@ -129,34 +80,22 @@ final class Exchange implements ExchangeInterface
         return $this->arguments[$key] ?? false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setArgument(string $key, $value)
+    public function setArgument(string $key, $value): void
     {
         $this->arguments[$key] = $value;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setArguments(array $arguments)
+    public function setArguments(array $arguments): void
     {
         $this->arguments = $arguments;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function declareExchange()
+    public function declareExchange(): void
     {
         $args = new AMQPTable($this->arguments);
 
@@ -173,10 +112,7 @@ final class Exchange implements ExchangeInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function delete(string $exchangeName = '', int $flags = Constants::AMQP_NOPARAM)
+    public function delete(string $exchangeName = '', int $flags = Constants::AMQP_NOPARAM): void
     {
         if ('' === $exchangeName) {
             $exchangeName = $this->name;
@@ -185,10 +121,7 @@ final class Exchange implements ExchangeInterface
         $this->channel->getResource()->exchange_delete($exchangeName, $flags);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function bind(string $exchangeName, string $routingKey = '', array $arguments = [])
+    public function bind(string $exchangeName, string $routingKey = '', array $arguments = []): void
     {
         $args = empty($arguments) ? null : new AMQPTable($arguments);
 
@@ -202,10 +135,7 @@ final class Exchange implements ExchangeInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = [])
+    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = []): void
     {
         $args = empty($arguments) ? null : new AMQPTable($arguments);
 
@@ -219,14 +149,11 @@ final class Exchange implements ExchangeInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function publish(
         string $message,
         string $routingKey = '',
         int $flags = Constants::AMQP_NOPARAM, array $attributes = []
-    ) {
+    ): void {
         $attributes['user_id'] = $this->getConnection()->getOptions()->getLogin();
         $message = new AMQPMessage($message, $attributes);
 
@@ -244,17 +171,11 @@ final class Exchange implements ExchangeInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getChannel(): ChannelInterface
     {
         return $this->channel;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConnection(): ConnectionInterface
     {
         return $this->channel->getConnection();

--- a/src/Driver/PhpAmqpLib/LazyConnection.php
+++ b/src/Driver/PhpAmqpLib/LazyConnection.php
@@ -38,20 +38,20 @@ final class LazyConnection extends AbstractConnection
 
         $this->options = $options;
         $this->connection = new \PhpAmqpLib\Connection\AMQPLazyConnection(
-            $options->getHost(),
-            $options->getPort(),
-            $options->getLogin(),
-            $options->getPassword(),
-            $options->getVhost(),
+            $options->host(),
+            $options->port(),
+            $options->login(),
+            $options->password(),
+            $options->vhost(),
             false,
             'AMQPLAIN',
             null,
             'en_US',
-            $options->getConnectTimeout(),
-            $options->getReadTimeout() ?: $options->getWriteTimeout(),
+            $options->connectTimeout(),
+            $options->readTimeout() ?: $options->writeTimeout(),
             null,
-            $options->getHeartbeat() > 0,
-            $options->getHeartbeat()
+            $options->heartbeat() > 0,
+            $options->heartbeat()
         );
     }
 }

--- a/src/Driver/PhpAmqpLib/LazyConnection.php
+++ b/src/Driver/PhpAmqpLib/LazyConnection.php
@@ -25,14 +25,9 @@ namespace Humus\Amqp\Driver\PhpAmqpLib;
 use Humus\Amqp\ConnectionOptions;
 use Traversable;
 
-/**
- * Class LazyConnection
- * @package Humus\Amqp\Driver\PhpAmqpLib
- */
 final class LazyConnection extends AbstractConnection
 {
     /**
-     * LazyConnection constructor.
      * @param ConnectionOptions|array|Traversable $options
      */
     public function __construct($options)

--- a/src/Driver/PhpAmqpLib/LazySocketConnection.php
+++ b/src/Driver/PhpAmqpLib/LazySocketConnection.php
@@ -27,14 +27,9 @@ use Humus\Amqp\ConnectionOptions;
 use PhpAmqpLib\Connection\AMQPLazySocketConnection as BaseLazySocketConnection;
 use Traversable;
 
-/**
- * Class LazySocketConnection
- * @package Humus\Amqp\Driver\PhpAmqpLib
- */
 final class LazySocketConnection extends AbstractConnection
 {
     /**
-     * SocketConnection constructor.
      * @param ConnectionOptions|array|Traversable $options
      */
     public function __construct($options)
@@ -59,9 +54,6 @@ final class LazySocketConnection extends AbstractConnection
         );
     }
 
-    /**
-     * @return ChannelInterface
-     */
     public function newChannel(): ChannelInterface
     {
         $method = new \ReflectionMethod($this->connection, 'connect');

--- a/src/Driver/PhpAmqpLib/LazySocketConnection.php
+++ b/src/Driver/PhpAmqpLib/LazySocketConnection.php
@@ -40,17 +40,17 @@ final class LazySocketConnection extends AbstractConnection
 
         $this->options = $options;
         $this->connection = new BaseLazySocketConnection(
-            $options->getHost(),
-            $options->getPort(),
-            $options->getLogin(),
-            $options->getPassword(),
-            $options->getVhost(),
+            $options->host(),
+            $options->port(),
+            $options->login(),
+            $options->password(),
+            $options->vhost(),
             false,
             'AMQPLAIN',
             null,
             'en_US',
-            $options->getReadTimeout() ?: $options->getWriteTimeout(),
-            $options->getHeartbeat() > 0
+            $options->readTimeout() ?: $options->writeTimeout(),
+            $options->heartbeat() > 0
         );
     }
 

--- a/src/Driver/PhpAmqpLib/Queue.php
+++ b/src/Driver/PhpAmqpLib/Queue.php
@@ -153,7 +153,7 @@ final class Queue implements QueueInterface
         string $consumerTag = null
     ): void {
         if (null !== $callback) {
-            $innerCallback = function (AMQPMessage $envelope) use ($callback) {
+            $innerCallback = function (AMQPMessage $envelope) use ($callback): bool {
                 $result = $callback(new Envelope($envelope), $this);
 
                 if (false === $result) {

--- a/src/Driver/PhpAmqpLib/Queue.php
+++ b/src/Driver/PhpAmqpLib/Queue.php
@@ -144,7 +144,7 @@ final class Queue implements QueueInterface
             return new Envelope($envelope);
         }
 
-        return false;
+        return null;
     }
 
     public function consume(

--- a/src/Driver/PhpAmqpLib/Queue.php
+++ b/src/Driver/PhpAmqpLib/Queue.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Driver\PhpAmqpLib;
 
-use http\Env;
 use Humus\Amqp\Channel as ChannelInterface;
 use Humus\Amqp\Connection as ConnectionInterface;
 use Humus\Amqp\Constants;

--- a/src/Driver/PhpAmqpLib/Queue.php
+++ b/src/Driver/PhpAmqpLib/Queue.php
@@ -185,7 +185,7 @@ final class Queue implements QueueInterface
                 $args
             );
 
-            $readTimeout = $this->getConnection()->getOptions()->getReadTimeout();
+            $readTimeout = $this->getConnection()->getOptions()->readTimeout();
 
             while ($this->channel->getResource()->is_consuming()) {
                 $this->channel->getResource()->wait(null, false, $readTimeout);

--- a/src/Driver/PhpAmqpLib/Queue.php
+++ b/src/Driver/PhpAmqpLib/Queue.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Driver\PhpAmqpLib;
 
+use http\Env;
 use Humus\Amqp\Channel as ChannelInterface;
 use Humus\Amqp\Connection as ConnectionInterface;
 use Humus\Amqp\Constants;
@@ -32,70 +33,35 @@ use PhpAmqpLib\Exception\AMQPRuntimeException;
 use PhpAmqpLib\Message\AMQPMessage;
 use PhpAmqpLib\Wire\AMQPTable;
 
-/**
- * Class Queue
- * @package Humus\Amqp\Driver\AmqpExtension
- */
 final class Queue implements QueueInterface
 {
-    /**
-     * @var Channel
-     */
-    private $channel;
+    private Channel $channel;
+    private string $name = '';
+    private int $flags = Constants::AMQP_NOPARAM;
+    private array $arguments = [];
 
-    /**
-     * @var string
-     */
-    private $name = '';
-
-    /**
-     * @var int
-     */
-    private $flags = Constants::AMQP_NOPARAM;
-
-    /**
-     * @var array
-     */
-    private $arguments = [];
-
-    /**
-     * Create an instance of an Queue object.
-     *
-     * @param Channel $channel The amqp channel to use.
-     */
+    /** @internal */
     public function __construct(Channel $channel)
     {
         $this->channel = $channel;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setName(string $exchangeName)
+    public function setName(string $exchangeName): void
     {
         $this->name = $exchangeName;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getFlags(): int
     {
         return $this->flags;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setFlags(int $flags)
+    public function setFlags(int $flags): void
     {
         $this->flags = (int) $flags;
     }
@@ -108,33 +74,21 @@ final class Queue implements QueueInterface
         return isset($this->arguments[$key]) ? $this->arguments[$key] : false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getArguments(): array
     {
         return $this->arguments;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setArgument(string $key, $value)
+    public function setArgument(string $key, $value): void
     {
         $this->arguments[$key] = $value;
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function setArguments(array $arguments)
+    public function setArguments(array $arguments): void
     {
         $this->arguments = $arguments;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function declareQueue(): int
     {
         $args = new AMQPTable($this->arguments);
@@ -161,10 +115,7 @@ final class Queue implements QueueInterface
         return $result[1];
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function bind(string $exchangeName, string $routingKey = null, array $arguments = [])
+    public function bind(string $exchangeName, string $routingKey = null, array $arguments = []): void
     {
         if (null === $routingKey) {
             $routingKey = '';
@@ -182,10 +133,7 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function get(int $flags = Constants::AMQP_NOPARAM)
+    public function get(int $flags = Constants::AMQP_NOPARAM): ?Envelope
     {
         $envelope = $this->channel->getResource()->basic_get(
             $this->name,
@@ -200,14 +148,11 @@ final class Queue implements QueueInterface
         return false;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function consume(
-        callable $callback = null,
+        ?callable $callback = null,
         int $flags = Constants::AMQP_NOPARAM,
         string $consumerTag = null
-    ) {
+    ): void {
         if (null !== $callback) {
             $innerCallback = function (AMQPMessage $envelope) use ($callback) {
                 $result = $callback(new Envelope($envelope), $this);
@@ -251,10 +196,7 @@ final class Queue implements QueueInterface
         }
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function ack(int $deliveryTag, int $flags = Constants::AMQP_NOPARAM)
+    public function ack(int $deliveryTag, int $flags = Constants::AMQP_NOPARAM): void
     {
         $this->channel->getResource()->basic_ack(
             $deliveryTag,
@@ -262,10 +204,7 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function nack(int $deliveryTag, int $flags = Constants::AMQP_NOPARAM)
+    public function nack(int $deliveryTag, int $flags = Constants::AMQP_NOPARAM): void
     {
         $this->channel->getResource()->basic_nack(
             $deliveryTag,
@@ -274,10 +213,7 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function reject(int $deliveryTag, int $flags = Constants::AMQP_NOPARAM)
+    public function reject(int $deliveryTag, int $flags = Constants::AMQP_NOPARAM): void
     {
         $this->channel->getResource()->basic_reject(
             $deliveryTag,
@@ -285,10 +221,7 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function purge()
+    public function purge(): void
     {
         $this->channel->getResource()->queue_purge(
             $this->name,
@@ -297,10 +230,7 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function cancel(string $consumerTag = '')
+    public function cancel(string $consumerTag = ''): void
     {
         $this->channel->getResource()->basic_cancel(
             $consumerTag,
@@ -309,10 +239,7 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = [])
+    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = []): void
     {
         $args = empty($arguments) ? null : new AMQPTable($arguments);
 
@@ -325,10 +252,7 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function delete(int $flags = Constants::AMQP_NOPARAM)
+    public function delete(int $flags = Constants::AMQP_NOPARAM): void
     {
         $this->channel->getResource()->queue_delete(
             $this->name,
@@ -339,17 +263,11 @@ final class Queue implements QueueInterface
         );
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getChannel(): ChannelInterface
     {
         return $this->channel;
     }
 
-    /**
-     * {@inheritdoc}
-     */
     public function getConnection(): ConnectionInterface
     {
         return $this->channel->getConnection();

--- a/src/Driver/PhpAmqpLib/SocketConnection.php
+++ b/src/Driver/PhpAmqpLib/SocketConnection.php
@@ -26,14 +26,9 @@ use Humus\Amqp\ConnectionOptions;
 use PhpAmqpLib\Connection\AMQPSocketConnection as BaseAMQPSocketConnection;
 use Traversable;
 
-/**
- * Class SocketConnection
- * @package Humus\Amqp\Driver\PhpAmqpLib
- */
 final class SocketConnection extends AbstractConnection
 {
     /**
-     * SocketConnection constructor.
      * @param ConnectionOptions|array|Traversable $options
      */
     public function __construct($options)

--- a/src/Driver/PhpAmqpLib/SocketConnection.php
+++ b/src/Driver/PhpAmqpLib/SocketConnection.php
@@ -39,19 +39,19 @@ final class SocketConnection extends AbstractConnection
 
         $this->options = $options;
         $this->connection = new BaseAMQPSocketConnection(
-            $options->getHost(),
-            $options->getPort(),
-            $options->getLogin(),
-            $options->getPassword(),
-            $options->getVhost(),
+            $options->host(),
+            $options->port(),
+            $options->login(),
+            $options->password(),
+            $options->vhost(),
             false,
             'AMQPLAIN',
             null,
             'en_US',
-            $options->getReadTimeout(),
-            $options->getHeartbeat() > 0,
-            $options->getWriteTimeout(),
-            $options->getHeartbeat()
+            $options->readTimeout(),
+            $options->heartbeat() > 0,
+            $options->writeTimeout(),
+            $options->heartbeat()
         );
     }
 }

--- a/src/Driver/PhpAmqpLib/SslConnection.php
+++ b/src/Driver/PhpAmqpLib/SslConnection.php
@@ -38,41 +38,41 @@ final class SslConnection extends AbstractConnection
             $options = new ConnectionOptions($options);
         }
 
-        if (true === $options->getVerify() && null === $options->getCACert()) {
+        if (true === $options->verify() && null === $options->caCert()) {
             throw new InvalidArgumentException('CA cert not set, so it can\'t be verified.');
         }
 
         $sslOptions = [];
 
-        if ($caCert = $options->getCACert()) {
+        if ($caCert = $options->caCert()) {
             $sslOptions['cafile'] = $caCert;
         }
 
-        if ($cert = $options->getCert()) {
+        if ($cert = $options->cert()) {
             $sslOptions['local_cert'] = $cert;
         }
 
-        if (null !== ($verify = $options->getVerify())) {
+        if (null !== ($verify = $options->verify())) {
             $sslOptions['verify_peer'] = $verify;
             $sslOptions['verify_peer_name'] = $verify;
         }
 
-        if ($key = $options->getKey()) {
+        if ($key = $options->key()) {
             $sslOptions['local_pk'] = $key;
         }
 
         $this->options = $options;
         $this->connection = new BaseAMQPSSLConnection(
-            $options->getHost(),
-            $options->getPort(),
-            $options->getLogin(),
-            $options->getPassword(),
-            $options->getVhost(),
+            $options->host(),
+            $options->port(),
+            $options->login(),
+            $options->password(),
+            $options->vhost(),
             $sslOptions,
             [
-                'connection_timeout' => $options->getReadTimeout(),
-                'read_write_timeout' => $options->getWriteTimeout(),
-                'heartbeat' => $options->getHeartbeat(),
+                'connection_timeout' => $options->readTimeout(),
+                'read_write_timeout' => $options->writeTimeout(),
+                'heartbeat' => $options->heartbeat(),
             ]
         );
     }

--- a/src/Driver/PhpAmqpLib/SslConnection.php
+++ b/src/Driver/PhpAmqpLib/SslConnection.php
@@ -27,14 +27,9 @@ use Humus\Amqp\Exception\InvalidArgumentException;
 use PhpAmqpLib\Connection\AMQPSSLConnection as BaseAMQPSSLConnection;
 use Traversable;
 
-/**
- * Class SslConnection
- * @package Humus\Amqp\Driver\PhpAmqpLib
- */
 final class SslConnection extends AbstractConnection
 {
     /**
-     * SslConnection constructor.
      * @param ConnectionOptions|array|Traversable $options
      */
     public function __construct($options)

--- a/src/Driver/PhpAmqpLib/StreamConnection.php
+++ b/src/Driver/PhpAmqpLib/StreamConnection.php
@@ -40,20 +40,20 @@ final class StreamConnection extends AbstractConnection
         $this->options = $options;
 
         $this->connection = new BaseAMQPStreamConnection(
-            $options->getHost(),
-            $options->getPort(),
-            $options->getLogin(),
-            $options->getPassword(),
-            $options->getVhost(),
+            $options->host(),
+            $options->port(),
+            $options->login(),
+            $options->password(),
+            $options->vhost(),
             false,
             'AMQPLAIN',
             null,
             'en_US',
-            $options->getConnectTimeout(),
-            $options->getReadTimeout() ?: $options->getWriteTimeout(),
+            $options->connectTimeout(),
+            $options->readTimeout() ?: $options->writeTimeout(),
             null,
-            $options->getHeartbeat() > 0,
-            $options->getHeartbeat()
+            $options->heartbeat() > 0,
+            $options->heartbeat()
         );
     }
 }

--- a/src/Driver/PhpAmqpLib/StreamConnection.php
+++ b/src/Driver/PhpAmqpLib/StreamConnection.php
@@ -26,14 +26,9 @@ use Humus\Amqp\ConnectionOptions;
 use PhpAmqpLib\Connection\AMQPStreamConnection as BaseAMQPStreamConnection;
 use Traversable;
 
-/**
- * Class StreamConnection
- * @package Humus\Amqp\Driver\PhpAmqpLib
- */
 final class StreamConnection extends AbstractConnection
 {
     /**
-     * StreamConnection constructor.
      * @param ConnectionOptions|array|Traversable $options
      */
     public function __construct($options)

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -165,9 +165,9 @@ interface Envelope
      * Get a specific message header.
      *
      * @param string $header Name of the header to get the value from.
-     * @return string|false The contents of the specified header, false if header not set
+     * @return string|null The contents of the specified header, null if header not set
      */
-    public function getHeader(string $header);
+    public function getHeader(string $header): ?string;
 
     /**
      * Check whether a specific message header is set.

--- a/src/Exception/AmqpException.php
+++ b/src/Exception/AmqpException.php
@@ -22,26 +22,16 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Interface AmqpException
- * @package Humus\Amqp\Exception
- */
-class AmqpException extends \Exception
+use Exception as BaseException;
+
+class AmqpException extends BaseException implements Exception
 {
-    /**
-     * @param \AMQPException $e
-     * @return AmqpException
-     */
-    public static function fromAmqpExtension(\AMQPException $e)
+    public static function fromAmqpExtension(\AMQPException $e): AmqpException
     {
         return new static($e->getMessage(), $e->getCode(), $e);
     }
 
-    /**
-     * @param \Exception $e
-     * @return AmqpException
-     */
-    public static function fromPhpAmqpLib(\Exception $e)
+    public static function fromPhpAmqpLib(BaseException $e): AmqpException
     {
         return new static($e->getMessage(), $e->getCode(), $e);
     }

--- a/src/Exception/BadMethodCallException.php
+++ b/src/Exception/BadMethodCallException.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class BadMethodCallException
- * @package Humus\Amqp\Exception
- */
 class BadMethodCallException extends \BadMethodCallException implements Exception
 {
 }

--- a/src/Exception/ChannelException.php
+++ b/src/Exception/ChannelException.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class ChannelException
- * @package Humus\Amqp\Exception
- */
 class ChannelException extends AmqpException
 {
 }

--- a/src/Exception/ConnectionException.php
+++ b/src/Exception/ConnectionException.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class ConnectionException
- * @package Humus\Amqp\Exception
- */
 class ConnectionException extends AmqpException
 {
 }

--- a/src/Exception/Exception.php
+++ b/src/Exception/Exception.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Interface Exception
- * @package Humus\Amqp\Exception
- */
 interface Exception
 {
 }

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class InvalidArgumentException
- * @package Humus\Amqp\Exception
- */
 class InvalidArgumentException extends \InvalidArgumentException implements Exception
 {
 }

--- a/src/Exception/InvalidJsonRpcRequest.php
+++ b/src/Exception/InvalidJsonRpcRequest.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class InvalidJsonRpcRequest
- * @package Humus\Amqp\Exception
- */
 final class InvalidJsonRpcRequest extends RuntimeException
 {
 }

--- a/src/Exception/InvalidJsonRpcVersion.php
+++ b/src/Exception/InvalidJsonRpcVersion.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class InvalidJsonRpcVersion
- * @package Humus\Amqp\Exception
- */
 final class InvalidJsonRpcVersion extends RuntimeException
 {
 }

--- a/src/Exception/JsonParseError.php
+++ b/src/Exception/JsonParseError.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class JsonParseError
- * @package Humus\Amqp\Exception
- */
 final class JsonParseError extends RuntimeException
 {
 }

--- a/src/Exception/QueueException.php
+++ b/src/Exception/QueueException.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class QueueException
- * @package Humus\Amqp\Exception
- */
 class QueueException extends AmqpException
 {
 }

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\Exception;
 
-/**
- * Class RuntimeException
- * @package Humus\Amqp\Exception
- */
 class RuntimeException extends \RuntimeException implements Exception
 {
 }

--- a/src/Exchange.php
+++ b/src/Exchange.php
@@ -24,48 +24,19 @@ namespace Humus\Amqp;
 
 /**
  * Represents a AMQP exchange
- *
- * Interface Exchange
- * @package Humus\Amqp
  */
 interface Exchange
 {
-    /**
-     * Get the configured name.
-     *
-     * @return string The configured name as a string.
-     */
     public function getName(): string;
 
-    /**
-     * Set the name of the exchange.
-     *
-     * @param string $exchangeName The name of the exchange to set as string.
-     *
-     * @return void
-     */
-    public function setName(string $exchangeName);
+    public function setName(string $exchangeName): void;
 
-    /**
-     * Get the configured type.
-     *
-     * @return string The configured type as a string.
-     */
     public function getType(): string;
 
-    /**
-     * Set the type of the exchange.
-     *
-     * @param string $exchangeType The type of exchange as a string.
-     * @return void
-     */
-    public function setType(string $exchangeType);
+    public function setType(string $exchangeType): void;
 
     /**
      * Get all the flags currently set on the given exchange.
-     *
-     * @return int An integer bitmask of all the flags currently set on this
-     *             exchange object.
      */
     public function getFlags(): int;
 
@@ -78,7 +49,7 @@ interface Exchange
      *                       and Constants::AMQP_DURABLE (needs librabbitmq version >= 0.5.3 when using with ext-amqp)
      * @return void
      */
-    public function setFlags(int $flags);
+    public function setFlags(int $flags): void;
 
     /**
      * Get the argument associated with the given key.
@@ -104,22 +75,14 @@ interface Exchange
      * @param string|integer $value Value of the argument to set.
      * @return void
      */
-    public function setArgument(string $key, $value);
+    public function setArgument(string $key, $value): void;
 
     /**
      * Set all arguments on the exchange.
-     *
-     * @param array $arguments An array of key/value pairs of arguments.
-     * @return void
      */
-    public function setArguments(array $arguments);
+    public function setArguments(array $arguments): void;
 
-    /**
-     * Declare a new exchange on the broker.
-     *
-     * @return void
-     */
-    public function declareExchange();
+    public function declareExchange(): void;
 
     /**
      * Delete the exchange from the broker.
@@ -131,7 +94,7 @@ interface Exchange
      *                              it.
      * @return void
      */
-    public function delete(string $exchangeName = '', int $flags = Constants::AMQP_NOPARAM);
+    public function delete(string $exchangeName = '', int $flags = Constants::AMQP_NOPARAM): void;
 
     /**
      * Bind to another exchange.
@@ -141,9 +104,10 @@ interface Exchange
      * @param string $exchangeName Name of the exchange to bind.
      * @param string $routingKey   The routing key to use for binding.
      * @param array  $arguments     Additional binding arguments.
+     *
      * @return void
      */
-    public function bind(string $exchangeName, string $routingKey = '', array $arguments = []);
+    public function bind(string $exchangeName, string $routingKey = '', array $arguments = []): void;
 
     /**
      * Remove binding to another exchange.
@@ -153,9 +117,10 @@ interface Exchange
      * @param string $exchangeName Name of the exchange to bind.
      * @param string $routingKey   The routing key to use for binding.
      * @param array  $arguments     Additional binding arguments.
+     *
      * @return void
      */
-    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = []);
+    public function unbind(string $exchangeName, string $routingKey = '', array $arguments = []): void;
 
     /**
      * Publish a message to an exchange.
@@ -176,19 +141,9 @@ interface Exchange
         string $routingKey = '',
         int $flags = Constants::AMQP_NOPARAM,
         array $attributes = []
-    );
+    ): void;
 
-    /**
-     * Get the Channel object in use
-     *
-     * @return Channel
-     */
     public function getChannel(): Channel;
 
-    /**
-     * Get the Connection object in use
-     *
-     * @return Connection
-     */
     public function getConnection(): Connection;
 }

--- a/src/FlushDeferredResult.php
+++ b/src/FlushDeferredResult.php
@@ -26,9 +26,6 @@ use MabeEnum\Enum;
 use MabeEnum\EnumSerializableTrait;
 
 /**
- * Class FlushDeferredResult
- * @package Humus\Amqp
- *
  * @method static FlushDeferredResult MSG_ACK()
  * @method static FlushDeferredResult MSG_REJECT()
  * @method static FlushDeferredResult MSG_REJECT_REQUEUE()

--- a/src/JsonProducer.php
+++ b/src/JsonProducer.php
@@ -41,17 +41,8 @@ final class JsonProducer extends AbstractProducer
         int $flags = Constants::AMQP_NOPARAM,
         array $attributes = []
     ) {
-        $attributes = array_merge_recursive($this->defaultAttributes, $attributes);
-
-        try {
-            $message = json_encode($message);
-        } catch (\Throwable $e) {
-            throw new InvalidArgumentException('Exception during json encoding', 0, $e);
-        }
-
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            throw new InvalidArgumentException('Error during json encoding');
-        }
+        $attributes = \array_merge_recursive($this->defaultAttributes, $attributes);
+        $message = \json_encode($message, JSON_THROW_ON_ERROR);
 
         $this->exchange->publish($message, $routingKey, $flags, $attributes);
     }

--- a/src/JsonProducer.php
+++ b/src/JsonProducer.php
@@ -22,8 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-use Humus\Amqp\Exception\InvalidArgumentException;
-
 final class JsonProducer extends AbstractProducer
 {
     protected array $defaultAttributes = [

--- a/src/JsonProducer.php
+++ b/src/JsonProducer.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-use HumusAmqp\Util\Json;
+use Humus\Amqp\Util\Json;
 
 final class JsonProducer extends AbstractProducer
 {

--- a/src/JsonProducer.php
+++ b/src/JsonProducer.php
@@ -24,16 +24,9 @@ namespace Humus\Amqp;
 
 use Humus\Amqp\Exception\InvalidArgumentException;
 
-/**
- * Class JsonProducer
- * @package Humus\Amqp
- */
 final class JsonProducer extends AbstractProducer
 {
-    /**
-     * @var array
-     */
-    protected $defaultAttributes = [
+    protected array $defaultAttributes = [
         'content_type' => 'application/json',
         'content_encoding' => 'UTF-8',
         'delivery_mode' => 2, // persistent

--- a/src/JsonRpc/Client.php
+++ b/src/JsonRpc/Client.php
@@ -22,8 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\JsonRpc;
 
-use Humus\Amqp\Exception;
-
 interface Client
 {
     public function addRequest(Request $request): void;

--- a/src/JsonRpc/Client.php
+++ b/src/JsonRpc/Client.php
@@ -24,25 +24,9 @@ namespace Humus\Amqp\JsonRpc;
 
 use Humus\Amqp\Exception;
 
-/**
- * Class JsonRpcClient
- * @package Humus\Amqp\JsonRpc
- */
 interface Client
 {
-    /**
-     * Add a request to rpc client
-     *
-     * @param Request $request
-     * @throws Exception\InvalidArgumentException
-     */
-    public function addRequest(Request $request);
+    public function addRequest(Request $request): void;
 
-    /**
-     * Get response collection
-     *
-     * @param float $timeout in seconds
-     * @return ResponseCollection
-     */
     public function getResponseCollection(float $timeout = 0): ResponseCollection;
 }

--- a/src/JsonRpc/Error.php
+++ b/src/JsonRpc/Error.php
@@ -22,21 +22,11 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\JsonRpc;
 
-/**
- * Class JsonRpcError
- * @package Humus\Amqp\JsonRpc
- */
 interface Error
 {
-    /**
-     * @return int
-     */
-    public function code();
+    public function code(): int;
 
-    /**
-     * @return string
-     */
-    public function message();
+    public function message(): string;
 
     /**
      * @return array|bool|float|int|null|string

--- a/src/JsonRpc/ErrorFactory.php
+++ b/src/JsonRpc/ErrorFactory.php
@@ -22,17 +22,14 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\JsonRpc;
 
-/**
- * Class JsonRpcError
- * @package Humus\Amqp\JsonRpc
- */
 interface ErrorFactory
 {
     /**
-     * JsonRpcError factory.
      * @param int $code
-     * @param ?string $message
+     * @param string|null $message
      * @param array|bool|float|int|null|string $data
+     *
+     * @return Error
      */
     public function create(int $code, ?string $message = null, $data = null): Error;
 }

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -28,6 +28,7 @@ use Humus\Amqp\Envelope;
 use Humus\Amqp\Exception;
 use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
+use HumusAmqp\Util\Json;
 
 final class JsonRpcClient implements Client
 {
@@ -70,9 +71,13 @@ final class JsonRpcClient implements Client
     {
         $attributes = $this->createAttributes($request);
         $exchange = $this->getExchange($request->server());
-        $message = \json_encode($request->params(), JSON_THROW_ON_ERROR);
 
-        $exchange->publish($message, $request->routingKey(), Constants::AMQP_NOPARAM, $attributes);
+        $exchange->publish(
+            Json::encode($request->params()),
+            $request->routingKey(),
+            Constants::AMQP_NOPARAM,
+            $attributes
+        );
 
         if (null !== $request->id()) {
             $this->requestIds[] = $request->id();
@@ -166,7 +171,7 @@ final class JsonRpcClient implements Client
             );
         }
 
-        $payload = \json_decode($envelope->getBody(), true);
+        $payload = Json::decode($envelope->getBody(), true);
 
         $correlationId = $envelope->getCorrelationId();
 

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -102,7 +102,7 @@ final class JsonRpcClient implements Client
 
         do {
             $message = $this->queue->get(Constants::AMQP_AUTOACK);
-
+var_dump($message);
             if ($message instanceof Envelope) {
                 $responseCollection->addResponse($this->responseFromEnvelope($message));
             } else {

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -143,7 +143,7 @@ final class JsonRpcClient implements Client
             'timestamp' => $request->timestamp(),
             'reply_to' => $this->queue->getName(),
             'app_id' => $this->appId,
-            'user_id' => $this->queue->getConnection()->getOptions()->getLogin(),
+            'user_id' => $this->queue->getConnection()->getOptions()->login(),
             'headers' => [
                 'jsonrpc' => JsonRpcRequest::JSONRPC_VERSION,
             ],

--- a/src/JsonRpc/JsonRpcClient.php
+++ b/src/JsonRpc/JsonRpcClient.php
@@ -28,7 +28,7 @@ use Humus\Amqp\Envelope;
 use Humus\Amqp\Exception;
 use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
-use HumusAmqp\Util\Json;
+use Humus\Amqp\Util\Json;
 
 final class JsonRpcClient implements Client
 {

--- a/src/JsonRpc/JsonRpcError.php
+++ b/src/JsonRpc/JsonRpcError.php
@@ -22,39 +22,22 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\JsonRpc;
 
-/**
- * Class JsonRpcError
- * @package Humus\Amqp\JsonRpc
- */
 final class JsonRpcError implements Error
 {
-    /**#@+
-     * @const int error codes
-     */
     const ERROR_CODE_32700 = -32700;
     const ERROR_CODE_32600 = -32600;
     const ERROR_CODE_32601 = -32601;
     const ERROR_CODE_32602 = -32602;
     const ERROR_CODE_32603 = -32603;
-    /**#@-*/
 
-    /**
-     * @var int
-     */
-    private $code;
-
-    /**
-     * @var
-     */
-    private $message;
-
+    private int $code;
+    private string $message;
     /**
      * @var array|bool|float|int|null|string
      */
     private $data;
 
     /**
-     * JsonRpcError constructor.
      * @param int $code
      * @param string $message
      * @param array|bool|float|int|null|string $data
@@ -66,18 +49,12 @@ final class JsonRpcError implements Error
         $this->data = $data;
     }
 
-    /**
-     * @return int
-     */
-    public function code()
+    public function code(): int
     {
         return $this->code;
     }
 
-    /**
-     * @return string
-     */
-    public function message()
+    public function message(): string
     {
         return $this->message;
     }

--- a/src/JsonRpc/JsonRpcErrorFactory.php
+++ b/src/JsonRpc/JsonRpcErrorFactory.php
@@ -24,27 +24,16 @@ namespace Humus\Amqp\JsonRpc;
 
 use Humus\Amqp\Exception;
 
-/**
- * Class JsonRpcError
- * @package Humus\Amqp\JsonRpc
- */
 final class JsonRpcErrorFactory implements ErrorFactory
 {
-    /**
-     * @var array Recommended Reason Phrases
-     */
-    private $recommendedMessagePhrases = [
+    private array $recommendedMessagePhrases = [
         -32700 => 'Parse error',
         -32600 => 'Invalid JsonRpcRequest',
         -32601 => 'Method not found',
         -32602 => 'Invalid params',
         -32603 => 'Internal error',
     ];
-
-    /**
-     * @var array Reason phrases for custom codes.
-     */
-    private $customMessagePhrases = [];
+    private array $customMessagePhrases = [];
 
     public function __construct(array $customCodes = [])
     {
@@ -52,10 +41,11 @@ final class JsonRpcErrorFactory implements ErrorFactory
     }
 
     /**
-     * JsonRpcError factory.
      * @param int $code
-     * @param ?string $message
+     * @param string|null $message
      * @param array|bool|float|int|null|string $data
+     *
+     * @return Error
      */
     public function create(int $code, ?string $message = null, $data = null): Error
     {

--- a/src/JsonRpc/JsonRpcRequest.php
+++ b/src/JsonRpc/JsonRpcRequest.php
@@ -35,7 +35,7 @@ final class JsonRpcRequest implements Request
      * @var array|string|int|float|bool
      */
     private $params;
-    private string $id;
+    private ?string $id;
     private string $routingKey;
     private int $expiration = 0;
     private int $timestamp;
@@ -44,9 +44,9 @@ final class JsonRpcRequest implements Request
      * @param string $server
      * @param string $method
      * @param array|string|int|float|bool $params
+     * @param string|null $id
      * @param string $routingKey
      * @param int $expiration in milliseconds
-     * @param string|null $id
      * @param int $timestamp
      *
      * @throws \Assert\AssertionFailedException
@@ -56,7 +56,7 @@ final class JsonRpcRequest implements Request
         string $server,
         string $method,
         $params,
-        string $id = null,
+        ?string $id = null,
         string $routingKey = '',
         int $expiration = 0, // in milliseconds
         int $timestamp = 0

--- a/src/JsonRpc/JsonRpcRequest.php
+++ b/src/JsonRpc/JsonRpcRequest.php
@@ -25,51 +25,22 @@ namespace Humus\Amqp\JsonRpc;
 use Assert\Assertion;
 use Humus\Amqp\Exception;
 
-/**
- * Class JsonRpcRequest
- * @package Humus\Amqp\JsonRpc
- */
 final class JsonRpcRequest implements Request
 {
     const JSONRPC_VERSION = '2.0';
 
-    /**
-     * @var string
-     */
-    private $server;
-
-    /**
-     * @var string
-     */
-    private $method;
+    private string $server;
+    private string $method;
     /**
      * @var array|string|int|float|bool
      */
     private $params;
+    private string $id;
+    private string $routingKey;
+    private int $expiration = 0;
+    private int $timestamp;
 
     /**
-     * @var string
-     */
-    private $id;
-
-    /**
-     * @var string
-     */
-    private $routingKey;
-
-    /**
-     * @var int
-     */
-    private $expiration = 0;
-
-    /**
-     * @var int
-     */
-    private $timestamp;
-
-    /**
-     * JsonRpcRequest constructor.
-     *
      * @param string $server
      * @param string $method
      * @param array|string|int|float|bool $params
@@ -77,6 +48,9 @@ final class JsonRpcRequest implements Request
      * @param int $expiration in milliseconds
      * @param string|null $id
      * @param int $timestamp
+     *
+     * @throws \Assert\AssertionFailedException
+     * @throws Exception\InvalidArgumentException
      */
     public function __construct(
         string $server,
@@ -110,50 +84,31 @@ final class JsonRpcRequest implements Request
         return $this->params;
     }
 
-    /**
-     * @return string
-     */
     public function server(): string
     {
         return $this->server;
     }
 
-    /**
-     * @return string
-     */
     public function routingKey(): string
     {
         return $this->routingKey;
     }
 
-    /**
-     * Expiration in milliseconds
-     * @return int
-     */
     public function expiration(): int
     {
         return $this->expiration;
     }
 
-    /**
-     * @return null|string
-     */
-    public function id()
+    public function id(): ?string
     {
         return $this->id;
     }
 
-    /**
-     * @return int
-     */
     public function timestamp(): int
     {
         return $this->timestamp;
     }
 
-    /**
-     * @return string
-     */
     public function method(): string
     {
         return $this->method;

--- a/src/JsonRpc/JsonRpcRequest.php
+++ b/src/JsonRpc/JsonRpcRequest.php
@@ -61,7 +61,7 @@ final class JsonRpcRequest implements Request
         int $expiration = 0, // in milliseconds
         int $timestamp = 0
     ) {
-        if (! is_array($params) && ! is_scalar($params) && null !== $params) {
+        if (! \is_array($params) && ! \is_scalar($params) && null !== $params) {
             throw new Exception\InvalidArgumentException('Params must be of type array, scalar or null');
         }
 

--- a/src/JsonRpc/JsonRpcResponse.php
+++ b/src/JsonRpc/JsonRpcResponse.php
@@ -41,7 +41,7 @@ final class JsonRpcResponse implements Response
      *
      * @return Response
      */
-    public static function withResult(?string $id, $result): Response
+    public static function withResult(?string $id, $result): JsonRpcResponse
     {
         $self = new self();
 
@@ -60,7 +60,7 @@ final class JsonRpcResponse implements Response
      *
      * @return Response
      */
-    public static function withError(?string $id, Error $error): Response
+    public static function withError(?string $id, Error $error): JsonRpcResponse
     {
         $self = new self();
 

--- a/src/JsonRpc/JsonRpcResponse.php
+++ b/src/JsonRpc/JsonRpcResponse.php
@@ -41,7 +41,7 @@ final class JsonRpcResponse implements Response
      *
      * @return Response
      */
-    public static function withResult(?string $id = null, $result): Response
+    public static function withResult(?string $id, $result): Response
     {
         $self = new self();
 
@@ -60,7 +60,7 @@ final class JsonRpcResponse implements Response
      *
      * @return Response
      */
-    public static function withError(?string $id = null, Error $error): Response
+    public static function withError(?string $id, Error $error): Response
     {
         $self = new self();
 

--- a/src/JsonRpc/JsonRpcResponse.php
+++ b/src/JsonRpc/JsonRpcResponse.php
@@ -32,8 +32,8 @@ final class JsonRpcResponse implements Response
      * @var array|string|int|float|bool|null
      */
     private $result;
-    private ?Error $error;
-    private string $id;
+    private ?Error $error = null;
+    private ?string $id;
 
     /**
      * @param string|null $id

--- a/src/JsonRpc/JsonRpcResponse.php
+++ b/src/JsonRpc/JsonRpcResponse.php
@@ -103,7 +103,7 @@ final class JsonRpcResponse implements Response
      */
     private static function assertPayload($payload, string $name): void
     {
-        if (is_array($payload)) {
+        if (\is_array($payload)) {
             foreach ($payload as $subPayload) {
                 self::assertPayload($subPayload, $name);
             }
@@ -111,7 +111,7 @@ final class JsonRpcResponse implements Response
             return;
         }
 
-        if (! is_scalar($payload) && null !== $payload) {
+        if (! \is_scalar($payload) && null !== $payload) {
             throw new Exception\InvalidArgumentException($name . ' must only contain arrays and scalar values');
         }
     }

--- a/src/JsonRpc/JsonRpcResponse.php
+++ b/src/JsonRpc/JsonRpcResponse.php
@@ -24,10 +24,6 @@ namespace Humus\Amqp\JsonRpc;
 
 use Humus\Amqp\Exception;
 
-/**
- * Class JsonRpcResponse
- * @package Humus\Amqp\JsonRpc
- */
 final class JsonRpcResponse implements Response
 {
     const JSONRPC_VERSION = '2.0';
@@ -36,23 +32,16 @@ final class JsonRpcResponse implements Response
      * @var array|string|int|float|bool|null
      */
     private $result;
-
-    /**
-     * @var Error|null
-     */
-    private $error;
-
-    /**
-     * @var string
-     */
-    private $id;
+    private ?Error $error;
+    private string $id;
 
     /**
      * @param string|null $id
      * @param array|string|int|float|bool|null $result
+     *
      * @return Response
      */
-    public static function withResult(string $id = null, $result)
+    public static function withResult(?string $id = null, $result): Response
     {
         $self = new self();
 
@@ -68,9 +57,10 @@ final class JsonRpcResponse implements Response
      * @param string|null $id
      * @param Error $error
      * @param array|string|int|float|bool|null $data
+     *
      * @return Response
      */
-    public static function withError(string $id = null, Error $error)
+    public static function withError(?string $id = null, Error $error): Response
     {
         $self = new self();
 
@@ -84,10 +74,7 @@ final class JsonRpcResponse implements Response
     {
     }
 
-    /**
-     * @return string|null
-     */
-    public function id()
+    public function id(): ?string
     {
         return $this->id;
     }
@@ -100,17 +87,11 @@ final class JsonRpcResponse implements Response
         return $this->result;
     }
 
-    /**
-     * @return Error|null
-     */
-    public function error()
+    public function error(): ?Error
     {
         return $this->error;
     }
 
-    /**
-     * @return bool
-     */
     public function isError(): bool
     {
         return null !== $this->error;
@@ -120,7 +101,7 @@ final class JsonRpcResponse implements Response
      * @param mixed $payload
      * @param string $name
      */
-    private static function assertPayload($payload, string $name)
+    private static function assertPayload($payload, string $name): void
     {
         if (is_array($payload)) {
             foreach ($payload as $subPayload) {

--- a/src/JsonRpc/JsonRpcResponseCollection.php
+++ b/src/JsonRpc/JsonRpcResponseCollection.php
@@ -23,31 +23,21 @@ declare(strict_types=1);
 namespace Humus\Amqp\JsonRpc;
 
 use ArrayIterator;
+use Iterator;
 
-/**
- * Class JsonRpcResponseCollection
- * @package Humus\Amqp\JsonRpc
- */
 final class JsonRpcResponseCollection implements ResponseCollection
 {
     /**
      * @var Response[]
      */
-    private $responses = [];
+    private array $responses = [];
 
-    /**
-     * @param Response $response
-     */
-    public function addResponse(Response $response)
+    public function addResponse(Response $response): void
     {
         $this->responses[] = $response;
     }
 
-    /**
-     * @param string $id
-     * @return Response|null
-     */
-    public function getResponse(string $id)
+    public function getResponse(string $id): ?Response
     {
         foreach ($this->responses as $response) {
             if ($response->id() === $id) {
@@ -56,11 +46,7 @@ final class JsonRpcResponseCollection implements ResponseCollection
         }
     }
 
-    /**
-     * @param string $id
-     * @return bool
-     */
-    public function hasResponse(string $id)
+    public function hasResponse(string $id): bool
     {
         foreach ($this->responses as $response) {
             if ($response->id() === $id) {
@@ -71,18 +57,12 @@ final class JsonRpcResponseCollection implements ResponseCollection
         return false;
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count(): int
     {
         return count($this->responses);
     }
 
-    /**
-     * @return ArrayIterator
-     */
-    public function getIterator()
+    public function getIterator(): Iterator
     {
         return new ArrayIterator($this->responses);
     }

--- a/src/JsonRpc/JsonRpcResponseCollection.php
+++ b/src/JsonRpc/JsonRpcResponseCollection.php
@@ -44,6 +44,8 @@ final class JsonRpcResponseCollection implements ResponseCollection
                 return $response;
             }
         }
+
+        return null;
     }
 
     public function hasResponse(string $id): bool

--- a/src/JsonRpc/JsonRpcServer.php
+++ b/src/JsonRpc/JsonRpcServer.php
@@ -30,7 +30,7 @@ use Humus\Amqp\Envelope;
 use Humus\Amqp\Exception;
 use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
-use HumusAmqp\Util\Json;
+use Humus\Amqp\Util\Json;
 use JsonException;
 use Psr\Log\LoggerInterface;
 use Throwable;

--- a/src/JsonRpc/Request.php
+++ b/src/JsonRpc/Request.php
@@ -22,10 +22,6 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\JsonRpc;
 
-/**
- * Class JsonRpcRequest
- * @package Humus\Amqp\JsonRpc
- */
 interface Request
 {
     /**
@@ -33,34 +29,15 @@ interface Request
      */
     public function params();
 
-    /**
-     * @return string
-     */
     public function server(): string;
 
-    /**
-     * @return string
-     */
     public function routingKey(): string;
 
-    /**
-     * Expiration in milliseconds
-     * @return int
-     */
     public function expiration(): int;
 
-    /**
-     * @return null|string
-     */
-    public function id();
+    public function id(): ?string;
 
-    /**
-     * @return int
-     */
     public function timestamp(): int;
 
-    /**
-     * @return string
-     */
     public function method(): string;
 }

--- a/src/JsonRpc/Response.php
+++ b/src/JsonRpc/Response.php
@@ -22,29 +22,16 @@ declare(strict_types=1);
 
 namespace Humus\Amqp\JsonRpc;
 
-/**
- * Class JsonRpcResponse
- * @package Humus\Amqp\JsonRpc
- */
 interface Response
 {
-    /**
-     * @return string|null
-     */
-    public function id();
+    public function id(): ?string;
 
     /**
      * @return array|bool|float|int|string|null
      */
     public function result();
 
-    /**
-     * @return Error|null
-     */
-    public function error();
+    public function error(): ?Error;
 
-    /**
-     * @return bool
-     */
     public function isError(): bool;
 }

--- a/src/JsonRpc/ResponseCollection.php
+++ b/src/JsonRpc/ResponseCollection.php
@@ -31,20 +31,9 @@ use IteratorAggregate;
  */
 interface ResponseCollection extends Countable, IteratorAggregate
 {
-    /**
-     * @param Response $response
-     */
-    public function addResponse(Response $response);
+    public function addResponse(Response $response): void;
 
-    /**
-     * @param string $id
-     * @return Response|null
-     */
-    public function getResponse(string $id);
+    public function getResponse(string $id): ?Response;
 
-    /**
-     * @param string $id
-     * @return bool
-     */
-    public function hasResponse(string $id);
+    public function hasResponse(string $id): bool;
 }

--- a/src/PlainProducer.php
+++ b/src/PlainProducer.php
@@ -22,16 +22,9 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-/**
- * Class PlainProducer
- * @package Humus\Amqp
- */
 final class PlainProducer extends AbstractProducer
 {
-    /**
-     * @var array
-     */
-    protected $defaultAttributes = [
+    protected array $defaultAttributes = [
         'content_type' => 'text/plain',
         'content_encoding' => 'UTF-8',
         'delivery_mode' => 2, // persistent

--- a/src/PlainProducer.php
+++ b/src/PlainProducer.php
@@ -38,7 +38,7 @@ final class PlainProducer extends AbstractProducer
         string $routingKey = '',
         int $flags = Constants::AMQP_NOPARAM, array $attributes = []
     ) {
-        $attributes = array_merge_recursive($this->defaultAttributes, $attributes);
+        $attributes = \array_merge_recursive($this->defaultAttributes, $attributes);
 
         $this->exchange->publish((string) $message, $routingKey, $flags, $attributes);
     }

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -22,19 +22,14 @@ declare(strict_types=1);
 
 namespace Humus\Amqp;
 
-use Humus\Amqp\Exception\ChannelException;
-use Humus\Amqp\Exception\QueueException;
+use JsonSerializable;
 
-/**
- * Interface Producer
- * @package Humus\Amqp
- */
 interface Producer
 {
     /**
      * Publish a message
      *
-     * @param string  $message     The message to publish.
+     * @param string|JsonSerializable  $message     The message to publish.
      * @param string  $routingKey  The optional routing key to which to
      *                             publish to.
      * @param int     $flags       One or more of Constants::AMQP_MANDATORY and
@@ -57,40 +52,29 @@ interface Producer
      *
      * This method must be called on the given channel prior to calling
      * Producer::commitTransaction() or Producer::rollbackTransaction().
-     *
-     * @return void
      */
-    public function startTransaction();
+    public function startTransaction(): void;
 
     /**
      * Commit a pending transaction.
-     *
-     * @return void
      */
-    public function commitTransaction();
+    public function commitTransaction(): void;
 
     /**
      * Rollback a transaction.
      *
      * Rollback an existing transaction. Producer::startTransaction() must
      * be called prior to this.
-     *
-     * @return void
      */
-    public function rollbackTransaction();
+    public function rollbackTransaction(): void;
 
     /**
      * Set the channel to use publisher acknowledgements. This can only used on a non-transactional channel.
-     *
-     * @return void
      */
-    public function confirmSelect();
+    public function confirmSelect(): void;
 
     /**
      * Set callback to process basic.ack and basic.nac AMQP server methods (applicable when channel in confirm mode).
-     *
-     * @param callable|null $ackCallback
-     * @param callable|null $nackCallback
      *
      * Callback functions with all arguments have the following signature:
      *
@@ -101,28 +85,18 @@ interface Producer
      *
      * Note, basic.nack server method will only be delivered if an internal error occurs in the Erlang process
      * responsible for a queue (see https://www.rabbitmq.com/confirms.html for details).
-     *
-     * @return void
      */
-    public function setConfirmCallback(callable $ackCallback = null, callable $nackCallback = null);
+    public function setConfirmCallback(?callable $ackCallback = null, ?callable $nackCallback = null): void;
 
     /**
      * Wait until all messages published since the last call have been either ack'd or nack'd by the broker.
      *
      * Note, this method also catch all basic.return message from server.
-     *
-     * @param float $timeout Timeout in seconds. May be fractional.
-     * @return void
-     * @throws ChannelException
-     * @throws QueueException
      */
-    public function waitForConfirm(float $timeout = 0.0);
+    public function waitForConfirm(float $timeout = 0.0): void;
 
     /**
      * Set callback to process basic.return AMQP server method
-     *
-     * @param callable|null $returnCallback
-     * @return void
      *
      * Callback function with all arguments has the following signature:
      *
@@ -136,15 +110,10 @@ interface Producer
      * and should return boolean false when wait loop should be canceled.
      *
      */
-    public function setReturnCallback(callable $returnCallback = null);
+    public function setReturnCallback(?callable $returnCallback = null): void;
 
     /**
      * Start wait loop for basic.return AMQP server methods
-     *
-     * @param float $timeout Timeout in seconds. May be fractional.
-     * @return void
-     * @throws ChannelException
-     * @throws QueueException
      */
-    public function waitForBasicReturn(float $timeout = 0.0);
+    public function waitForBasicReturn(float $timeout = 0.0): void;
 }

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -140,9 +140,9 @@ interface Queue
      *                       value is not provided, it will use the
      *                       value of ini-setting amqp.auto_ack.
      *
-     * @return Envelope|false
+     * @return Envelope|null
      */
-    public function get(int $flags = Constants::AMQP_NOPARAM);
+    public function get(int $flags = Constants::AMQP_NOPARAM): ?Envelope;
 
     /**
      * Consume messages from a queue.
@@ -175,7 +175,7 @@ interface Queue
      *
      *      function callback(Envelope $envelope, Queue $queue = null): bool;
      */
-    public function consume(callable $callback = null, int $flags = Constants::AMQP_NOPARAM, string $consumerTag = '');
+    public function consume(?callable $callback = null, int $flags = Constants::AMQP_NOPARAM, string $consumerTag = '');
 
     /**
      * Acknowledge the receipt of a message.

--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-namespace HumusAmqp\Util;
+namespace Humus\Amqp\Util;
 
 class Json
 {

--- a/src/Util/Json.php
+++ b/src/Util/Json.php
@@ -20,29 +20,31 @@
 
 declare(strict_types=1);
 
-namespace Humus\Amqp;
+namespace HumusAmqp\Util;
 
-use HumusAmqp\Util\Json;
-
-final class JsonProducer extends AbstractProducer
+class Json
 {
-    protected array $defaultAttributes = [
-        'content_type' => 'application/json',
-        'content_encoding' => 'UTF-8',
-        'delivery_mode' => 2, // persistent
-    ];
+    /**
+     * @param mixed $value
+     * @return string
+     */
+    public static function encode($value): string
+    {
+        $flags = \JSON_UNESCAPED_UNICODE | \JSON_UNESCAPED_SLASHES | \JSON_PRESERVE_ZERO_FRACTION | \JSON_THROW_ON_ERROR;
+
+        return \json_encode($value, $flags);
+    }
 
     /**
-     * {@inheritdoc}
+     * @param string $json
+     * @return mixed
      */
-    public function publish(
-        $message,
-        string $routingKey = '',
-        int $flags = Constants::AMQP_NOPARAM,
-        array $attributes = []
-    ) {
-        $attributes = \array_merge_recursive($this->defaultAttributes, $attributes);
+    public static function decode(string $json)
+    {
+        return \json_decode($json, true, 512, \JSON_BIGINT_AS_STRING | \JSON_THROW_ON_ERROR);
+    }
 
-        $this->exchange->publish(Json::encode($message), $routingKey, $flags, $attributes);
+    final private function __construct()
+    {
     }
 }

--- a/tests/AbstractCallbackConsumerTest.php
+++ b/tests/AbstractCallbackConsumerTest.php
@@ -72,7 +72,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_ACK();
@@ -180,7 +180,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_REJECT();
@@ -289,7 +289,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             new NullLogger(),
             7,
-            function (Envelope $envelope, Queue $queue) use (&$result, &$i) {
+            function (Envelope $envelope, Queue $queue) use (&$result, &$i): DeliveryResult {
                 $i++;
                 if ((int) $envelope->getBody() % 2 === 0 && ! $envelope->isRedelivery()) {
                     $result[] = $envelope->getBody();
@@ -340,7 +340,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_DEFER();
@@ -425,12 +425,12 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_DEFER();
             },
-            function (Queue $queue) {
+            function (Queue $queue): FlushDeferredResult {
                 return FlushDeferredResult::MSG_REJECT_REQUEUE();
             },
             null,
@@ -513,12 +513,12 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_DEFER();
             },
-            function () use (&$result) {
+            function () use (&$result): FlushDeferredResult {
                 $result[] = 'flushed';
 
                 return FlushDeferredResult::MSG_REJECT();
@@ -619,12 +619,12 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             new NullLogger(),
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_DEFER();
             },
-            function () use (&$result, &$flushes) {
+            function () use (&$result, &$flushes): FlushDeferredResult {
                 $flushes++;
                 $result[] = 'flushed';
                 if (1 === $flushes) {
@@ -676,12 +676,14 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): void {
                 throw new \Exception('foo');
             },
             null,
-            function (\Exception $e) use (&$result) {
+            function (\Exception $e) use (&$result): bool {
                 $result[] = $e->getMessage();
+
+                return true;
             }
         );
 
@@ -767,11 +769,11 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): void {
                 throw new \Exception('foo');
             },
             null,
-            function (\Exception $e) use (&$result) {
+            function (\Exception $e) use (&$result): bool {
                 $result[] = $e->getMessage();
 
                 return true;
@@ -860,11 +862,11 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): void {
                 throw new \Exception('foo');
             },
             null,
-            function (\Exception $e) use (&$result) {
+            function (\Exception $e) use (&$result): bool {
                 $result[] = $e->getMessage();
 
                 return false;
@@ -953,16 +955,18 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_DEFER();
             },
-            function () {
+            function (): void {
                 throw new \Exception('foo');
             },
-            function (\Exception $e) use (&$result) {
+            function (\Exception $e) use (&$result): bool {
                 $result[] = $e->getMessage();
+
+                return true;
             }
         );
 
@@ -1043,7 +1047,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_ACK();
@@ -1151,7 +1155,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_ACK();
@@ -1279,7 +1283,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_ACK();
@@ -1346,7 +1350,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
             $queue,
             $logger,
             3,
-            function (Envelope $envelope, Queue $queue) use (&$result) {
+            function (Envelope $envelope, Queue $queue) use (&$result): DeliveryResult {
                 $result[] = $envelope->getBody();
 
                 return DeliveryResult::MSG_ACK();

--- a/tests/AbstractCallbackConsumerTest.php
+++ b/tests/AbstractCallbackConsumerTest.php
@@ -35,10 +35,6 @@ use HumusTest\Amqp\TestAsset\ArrayLogger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
-/**
- * Class AbstractCallbackConsumer
- * @package HumusTest\Amqp
- */
 abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreateConnection
 {
     use DeleteOnTearDownTrait;
@@ -46,7 +42,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_processes_messages_and_acks()
+    public function it_processes_messages_and_acks(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -154,7 +150,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_processes_messages_and_rejects()
+    public function it_processes_messages_and_rejects(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -262,7 +258,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_processes_messages_rejects_and_requeues()
+    public function it_processes_messages_rejects_and_requeues(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -314,7 +310,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_processes_messages_defers_and_acks_block()
+    public function it_processes_messages_defers_and_acks_block(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -400,7 +396,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_handles_flush_deferred_after_timeout()
+    public function it_handles_flush_deferred_after_timeout(): void
     {
         $connection = $this->createConnection(new ConnectionOptions(['read_timeout' => 1]));
         $channel = $connection->newChannel();
@@ -487,7 +483,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_uses_custom_flush_deferred_callback()
+    public function it_uses_custom_flush_deferred_callback(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -592,7 +588,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_rejects_and_requeues_on_flush_deferred()
+    public function it_rejects_and_requeues_on_flush_deferred(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -650,7 +646,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_handles_delivery_exception()
+    public function it_handles_delivery_exception(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -741,7 +737,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_handles_delivery_exception_when_error_callback_returns_true()
+    public function it_handles_delivery_exception_when_error_callback_returns_true(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -834,7 +830,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_handles_delivery_exception_when_error_callback_returns_false()
+    public function it_handles_delivery_exception_when_error_callback_returns_false(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -927,7 +923,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_handles_flush_deferred_exception()
+    public function it_handles_flush_deferred_exception(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -1008,7 +1004,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_handles_shutdown_message()
+    public function it_handles_shutdown_message(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -1105,7 +1101,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_handles_reconfigure_message()
+    public function it_handles_reconfigure_message(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -1245,7 +1241,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_errors_invalid_reconfigure_message()
+    public function it_errors_invalid_reconfigure_message(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -1314,7 +1310,7 @@ abstract class AbstractCallbackConsumerTest extends TestCase implements CanCreat
     /**
      * @test
      */
-    public function it_errors_invalid_internal_message()
+    public function it_errors_invalid_internal_message(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();

--- a/tests/AbstractChannelRecoverTest.php
+++ b/tests/AbstractChannelRecoverTest.php
@@ -78,7 +78,7 @@ abstract class AbstractChannelRecoverTest extends TestCase implements CanCreateC
         // NOTE: by default prefetch-count=3, so in consumer below we will ignore prefetched messages 3-5,
         //       and they will not seen by other consumers until we redeliver it.
 
-        $queue1->consume(function (Envelope $envelope, Queue $queue) use (&$consume, &$result) {
+        $queue1->consume(function (Envelope $envelope, Queue $queue) use (&$consume, &$result): bool {
             $result[] = 'consumed ' . $envelope->getBody() . ' '
                 . ($envelope->isRedelivery() ? '(redelivered)' : '(original)');
             $queue->ack($envelope->getDeliveryTag());
@@ -98,7 +98,7 @@ abstract class AbstractChannelRecoverTest extends TestCase implements CanCreateC
         $consume = 10;
 
         try {
-            $queue2->consume(function (Envelope $envelope, Queue $queue) use (&$consume, &$result) {
+            $queue2->consume(function (Envelope $envelope, Queue $queue) use (&$consume, &$result): bool {
                 $result[] = 'consumed ' . $envelope->getBody() . ' '
                     . ($envelope->isRedelivery() ? '(redelivered)' : '(original)');
                 $queue->ack($envelope->getDeliveryTag());
@@ -119,7 +119,7 @@ abstract class AbstractChannelRecoverTest extends TestCase implements CanCreateC
 
         $consume = 10;
         try {
-            $queue2->consume(function (Envelope $e, Queue $q) use (&$consume, &$result) {
+            $queue2->consume(function (Envelope $e, Queue $q) use (&$consume, &$result): bool {
                 $result[] = 'consumed ' . $e->getBody() . ' ' . ($e->isRedelivery() ? '(redelivered)' : '(original)');
                 $q->ack($e->getDeliveryTag());
 

--- a/tests/AbstractChannelRecoverTest.php
+++ b/tests/AbstractChannelRecoverTest.php
@@ -31,21 +31,10 @@ use Humus\Amqp\Queue;
 use HumusTest\Amqp\Helper\CanCreateConnection;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class AbstractChannelRecoverTest
- * @package HumusTest\Amqp
- */
 abstract class AbstractChannelRecoverTest extends TestCase implements CanCreateConnection
 {
-    /**
-     * @var Exchange
-     */
-    private $exchange;
-
-    /**
-     * @var Queue
-     */
-    private $queue;
+    private Exchange $exchange;
+    private Queue $queue;
 
     protected function tearDown(): void
     {
@@ -56,7 +45,7 @@ abstract class AbstractChannelRecoverTest extends TestCase implements CanCreateC
     /**
      * @test
      */
-    public function it_recovers()
+    public function it_recovers(): void
     {
         $result = [];
 

--- a/tests/AbstractChannelTest.php
+++ b/tests/AbstractChannelTest.php
@@ -29,21 +29,10 @@ use Humus\Amqp\Queue;
 use HumusTest\Amqp\Helper\CanCreateConnection;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class AbstractChannelTest
- * @package HumusTest\Amqp
- */
 abstract class AbstractChannelTest extends TestCase implements CanCreateConnection
 {
-    /**
-     * @var Connection
-     */
-    protected $connection;
-
-    /**
-     * @var Channel
-     */
-    protected $channel;
+    protected Connection $connection;
+    protected Channel $channel;
 
     protected function setUp(): void
     {
@@ -54,7 +43,7 @@ abstract class AbstractChannelTest extends TestCase implements CanCreateConnecti
     /**
      * @test
      */
-    public function it_returns_channel_id()
+    public function it_returns_channel_id(): void
     {
         $this->assertEquals(1, $this->channel->getChannelId());
     }
@@ -62,7 +51,7 @@ abstract class AbstractChannelTest extends TestCase implements CanCreateConnecti
     /**
      * @test
      */
-    public function it_returns_connection()
+    public function it_returns_connection(): void
     {
         $connection = $this->channel->getConnection();
 
@@ -74,7 +63,7 @@ abstract class AbstractChannelTest extends TestCase implements CanCreateConnecti
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_creates_multiple_channels()
+    public function it_creates_multiple_channels(): void
     {
         $this->connection->newChannel();
     }
@@ -82,7 +71,7 @@ abstract class AbstractChannelTest extends TestCase implements CanCreateConnecti
     /**
      * @test
      */
-    public function it_creates_new_exchange()
+    public function it_creates_new_exchange(): void
     {
         $channel = $this->connection->newChannel();
 
@@ -94,7 +83,7 @@ abstract class AbstractChannelTest extends TestCase implements CanCreateConnecti
     /**
      * @test
      */
-    public function it_creates_new_queue()
+    public function it_creates_new_queue(): void
     {
         $channel = $this->connection->newChannel();
 
@@ -106,7 +95,7 @@ abstract class AbstractChannelTest extends TestCase implements CanCreateConnecti
     /**
      * @test
      */
-    public function it_changes_qos()
+    public function it_changes_qos(): void
     {
         $channel = $this->connection->newChannel();
         $channel->qos(0, 5);

--- a/tests/AbstractConnectionTest.php
+++ b/tests/AbstractConnectionTest.php
@@ -27,15 +27,8 @@ use Humus\Amqp\ConnectionOptions;
 use HumusTest\Amqp\Helper\CanCreateConnection;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class AbstractConnectionTest
- * @package HumusTest\Amqp
- */
 abstract class AbstractConnectionTest extends TestCase implements CanCreateConnection
 {
-    /**
-     * @return ConnectionOptions
-     */
     protected function invalidCredentials(): ConnectionOptions
     {
         return new ConnectionOptions([
@@ -50,7 +43,7 @@ abstract class AbstractConnectionTest extends TestCase implements CanCreateConne
     /**
      * @test
      */
-    public function it_creates_new_channel()
+    public function it_creates_new_channel(): void
     {
         $connection = $this->createConnection();
 

--- a/tests/AbstractExchangeTest.php
+++ b/tests/AbstractExchangeTest.php
@@ -446,7 +446,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
 
         $this->addToCleanUp($queue);
 
-        $this->assertFalse($queue->get());
+        $this->assertNull($queue->get());
 
         try {
             $this->channel->waitForBasicReturn(1);

--- a/tests/AbstractExchangeTest.php
+++ b/tests/AbstractExchangeTest.php
@@ -34,28 +34,13 @@ use HumusTest\Amqp\Helper\CanCreateConnection;
 use HumusTest\Amqp\Helper\DeleteOnTearDownTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class AbstractExchangeTest
- * @package HumusTest\Amqp
- */
 abstract class AbstractExchangeTest extends TestCase implements CanCreateConnection
 {
     use DeleteOnTearDownTrait;
 
-    /**
-     * @var Exchange
-     */
-    protected $exchange;
-
-    /**
-     * @var Queue
-     */
-    protected $queue;
-
-    /**
-     * @var Channel
-     */
-    protected $channel;
+    protected Exchange $exchange;
+    protected Queue $queue;
+    protected Channel $channel;
 
     protected function setUp(): void
     {
@@ -68,7 +53,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
     /**
      * @test
      */
-    public function it_sets_name_flags_type_and_arguments()
+    public function it_sets_name_flags_type_and_arguments(): void
     {
         $this->assertEquals('', $this->exchange->getName());
         $this->assertEquals('', $this->exchange->getType());
@@ -112,7 +97,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_declares_and_deletes_exchange()
+    public function it_declares_and_deletes_exchange(): void
     {
         $this->addToCleanUp($this->exchange);
         $this->exchange->setType('direct');
@@ -124,7 +109,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_declares_exchange_with_arguments()
+    public function it_declares_exchange_with_arguments(): void
     {
         $this->addToCleanUp($this->exchange);
         $this->exchange->setType('direct');
@@ -146,7 +131,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
     /**
      * @test
      */
-    public function it_returns_channel_and_connection()
+    public function it_returns_channel_and_connection(): void
     {
         $this->assertInstanceOf(Channel::class, $this->exchange->getChannel());
         $this->assertInstanceOf(Connection::class, $this->exchange->getConnection());
@@ -156,7 +141,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_binds_and_unbinds_to_exchange()
+    public function it_binds_and_unbinds_to_exchange(): void
     {
         $this->addToCleanUp($this->exchange);
         $this->exchange->setType('direct');
@@ -181,7 +166,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_binds_and_unbinds_to_exchange_with_routing_key()
+    public function it_binds_and_unbinds_to_exchange_with_routing_key(): void
     {
         $this->addToCleanUp($this->exchange);
         $this->exchange->setType('direct');
@@ -206,7 +191,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_binds_and_unbinds_to_exchange_with_arguments()
+    public function it_binds_and_unbinds_to_exchange_with_arguments(): void
     {
         $this->addToCleanUp($this->exchange);
         $this->exchange->setType('direct');
@@ -251,7 +236,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_binds_and_unbinds_to_exchange_with_routing_key_and_arguments()
+    public function it_binds_and_unbinds_to_exchange_with_routing_key_and_arguments(): void
     {
         $this->addToCleanUp($this->exchange);
         $this->exchange->setType('direct');
@@ -275,7 +260,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
     /**
      * @test
      */
-    public function it_publishes_with_confirms()
+    public function it_publishes_with_confirms(): void
     {
         $result = [];
 
@@ -389,7 +374,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
     /**
      * @test
      */
-    public function it_throws_exception_when_negative_wait_confirm_timeout_given()
+    public function it_throws_exception_when_negative_wait_confirm_timeout_given(): void
     {
         $this->expectException(ChannelException::class);
         $this->expectExceptionMessage('Timeout must be greater than or equal to zero.');
@@ -404,7 +389,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
     /**
      * @test
      */
-    public function it_produces_in_confirm_mode()
+    public function it_produces_in_confirm_mode(): void
     {
         $this->exchange->setType('topic');
         $this->exchange->setName('test-exchange');
@@ -446,7 +431,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
     /**
      * @test
      */
-    public function it_publishes_mandatory()
+    public function it_publishes_mandatory(): void
     {
         $result = [];
 

--- a/tests/AbstractExchangeTest.php
+++ b/tests/AbstractExchangeTest.php
@@ -264,7 +264,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
     {
         $result = [];
 
-        set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline) use (&$result) {
+        set_error_handler(function (int $errno, string $errstr, string $errfile, int $errline) use (&$result): void {
             $result[] = $errstr;
         });
 
@@ -312,8 +312,10 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
             string $routingKey,
             Envelope $envelope,
             string $body
-        ) use (&$result) {
+        ) use (&$result): bool {
             $result[] = 'Message returned: ' . $replyText . ', message body:' . $body;
+
+            return true;
         });
 
         $cnt = 2;
@@ -322,7 +324,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
             function (
                 int $deliveryTag,
                 bool $multiple = false
-            ) use (&$cnt, &$result) {
+            ) use (&$cnt, &$result): bool {
                 $result[] = 'Message acked';
 
                 return --$cnt > 0;
@@ -331,7 +333,7 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
                 int $deliveryTag,
                 bool $multiple,
                 bool $requeue
-            ) use (&$result) {
+            ) use (&$result): bool {
                 $result[] = 'Message nacked';
 
                 return false;
@@ -396,10 +398,10 @@ abstract class AbstractExchangeTest extends TestCase implements CanCreateConnect
         $this->exchange->declareExchange();
 
         $this->exchange->getChannel()->setConfirmCallback(
-            function () {
+            function (): bool {
                 return false;
             },
-            function (int $deliveryTag, bool $multiple, bool $requeue) {
+            function (int $deliveryTag, bool $multiple, bool $requeue): void {
                 throw new \Exception('Could not confirm message publishing');
             }
         );

--- a/tests/AbstractJsonProducerTest.php
+++ b/tests/AbstractJsonProducerTest.php
@@ -388,15 +388,14 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
      */
     public function it_throws_exception_when_data_could_not_be_encoded_to_json(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Error during json encoding');
-
         $exchange = $this->prophesize(Exchange::class);
         $exchange->publish(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
 
         $producer = new JsonProducer($exchange->reveal());
 
         $text = "\xB1\x31";
+
+        $this->expectException(\JsonException::class);
 
         $producer->publish($text);
     }
@@ -406,9 +405,6 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
      */
     public function it_throws_exception_when_data_could_not_be_encoded_to_json_2(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Exception during json encoding');
-
         $exchange = $this->prophesize(Exchange::class);
         $exchange->publish(Argument::any(), Argument::any(), Argument::any(), Argument::any())->shouldNotBeCalled();
 
@@ -420,6 +416,8 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
                 throw new \Exception('foo');
             }
         };
+
+        $this->expectException(\Exception::class);
 
         $producer->publish($message);
     }

--- a/tests/AbstractJsonProducerTest.php
+++ b/tests/AbstractJsonProducerTest.php
@@ -124,10 +124,10 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
         $count = 2;
 
         $this->exchange->getChannel()->setConfirmCallback(
-            function (int $delivery_tag, bool $multiple) use (&$count) {
+            function (int $delivery_tag, bool $multiple) use (&$count): bool {
                 return $delivery_tag !== $count;
             },
-            function (int $delivery_tag, bool $multiple, bool $requeue) {
+            function (int $delivery_tag, bool $multiple, bool $requeue): bool {
                 throw new \Exception('Could not confirm message publishing');
             }
         );
@@ -165,12 +165,10 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
         $count = 1;
 
         $this->exchange->getChannel()->setConfirmCallback(
-            function (int $delivery_tag, bool $multiple) use (&$count) {
-                var_dump(__LINE__, $delivery_tag, $count);
-
+            function (int $delivery_tag, bool $multiple) use (&$count): bool {
                 return $delivery_tag !== $count;
             },
-            function (int $delivery_tag, bool $multiple, bool $requeue) {
+            function (int $delivery_tag, bool $multiple, bool $requeue): void {
                 throw new \Exception('Could not confirm message publishing');
             }
         );
@@ -191,10 +189,10 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
         $count = 2;
 
         $this->exchange->getChannel()->setConfirmCallback(
-            function (int $delivery_tag, bool $multiple) use (&$count) {
+            function (int $delivery_tag, bool $multiple) use (&$count): bool {
                 return $delivery_tag !== $count;
             },
-            function (int $delivery_tag, bool $multiple, bool $requeue) {
+            function (int $delivery_tag, bool $multiple, bool $requeue): void {
                 throw new \Exception('Could not confirm message publishing');
             }
         );
@@ -258,7 +256,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
         $producer->confirmSelect();
 
         $producer->setConfirmCallback(
-            function (int $deliveryTag, bool $multiple) use (&$result, &$multipleAcks) {
+            function (int $deliveryTag, bool $multiple) use (&$result, &$multipleAcks): bool {
                 $result[] = 'acked ' . (string) $deliveryTag;
                 if ($multiple) {
                     $multipleAcks = $multiple;
@@ -266,7 +264,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
 
                 return 3 !== $deliveryTag;
             },
-            function (int $deliveryTag, bool $multiple, bool $requeue) use (&$result) {
+            function (int $deliveryTag, bool $multiple, bool $requeue) use (&$result): bool {
                 $result[] = 'nacked' . (string) $deliveryTag;
 
                 return false;
@@ -319,12 +317,12 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
 
         $cnt = 2;
         $producer->setConfirmCallback(
-            function ($deliveryTag, bool $multiple) use (&$result, &$cnt) {
+            function ($deliveryTag, bool $multiple) use (&$result, &$cnt): bool {
                 $result[] = 'acked ' . (string) $deliveryTag;
 
                 return --$cnt > 0;
             },
-            function ($deliveryTag, bool $multiple, bool $requeue) use (&$result) {
+            function ($deliveryTag, bool $multiple, bool $requeue) use (&$result): bool {
                 $result = 'nacked' . (string) $deliveryTag;
 
                 return false;
@@ -363,7 +361,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
             string $routingKey,
             Envelope $envelope,
             string $body
-        ) use (&$result) {
+        ) use (&$result): bool {
             $result[] = 'Message returned';
             $result[] = func_get_args();
 

--- a/tests/AbstractJsonProducerTest.php
+++ b/tests/AbstractJsonProducerTest.php
@@ -25,7 +25,6 @@ namespace HumusTest\Amqp;
 use Humus\Amqp\Channel;
 use Humus\Amqp\Constants;
 use Humus\Amqp\Envelope;
-use Humus\Amqp\Exception\InvalidArgumentException;
 use Humus\Amqp\Exchange;
 use Humus\Amqp\JsonProducer;
 use Humus\Amqp\Queue;

--- a/tests/AbstractJsonProducerTest.php
+++ b/tests/AbstractJsonProducerTest.php
@@ -34,38 +34,15 @@ use HumusTest\Amqp\Helper\DeleteOnTearDownTrait;
 use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 
-/**
- * Class AbstractJsonProducerTest
- * @package HumusTest\Amqp
- */
 abstract class AbstractJsonProducerTest extends TestCase implements CanCreateConnection
 {
     use DeleteOnTearDownTrait;
 
-    /**
-     * @var Channel
-     */
-    protected $channel;
-
-    /**
-     * @var Exchange
-     */
-    protected $exchange;
-
-    /**
-     * @var Queue
-     */
-    protected $queue;
-
-    /**
-     * @var JsonProducer
-     */
-    protected $producer;
-
-    /**
-     * @var array
-     */
-    protected $results = [];
+    protected Channel $channel;
+    protected Exchange $exchange;
+    protected Queue $queue;
+    protected JsonProducer $producer;
+    protected array $results = [];
 
     protected function setUp(): void
     {
@@ -95,7 +72,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_produces_and_get_messages_from_queue()
+    public function it_produces_and_get_messages_from_queue(): void
     {
         $producer = new JsonProducer($this->exchange);
         $producer->publish(['foo' => 'bar']);
@@ -119,7 +96,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_produces_transactional_and_get_messages_from_queue()
+    public function it_produces_transactional_and_get_messages_from_queue(): void
     {
         $producer = new JsonProducer($this->exchange);
         $producer->startTransaction();
@@ -142,7 +119,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_produces_in_confirm_mode()
+    public function it_produces_in_confirm_mode(): void
     {
         $count = 2;
 
@@ -183,7 +160,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_produces_in_nested_confirm_mode()
+    public function it_produces_in_nested_confirm_mode(): void
     {
         $count = 1;
 
@@ -238,7 +215,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_sends_given_attributes()
+    public function it_sends_given_attributes(): void
     {
         $producer = new JsonProducer($this->exchange, [
             'content_type' => 'application/json',
@@ -271,7 +248,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_uses_confirm_callback()
+    public function it_uses_confirm_callback(): void
     {
         $result = [];
         $multipleAcks = false;
@@ -326,7 +303,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_uses_confirm_callback_and_fails()
+    public function it_uses_confirm_callback_and_fails(): void
     {
         $result = [];
         $message = '';
@@ -370,7 +347,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_uses_return_callback()
+    public function it_uses_return_callback(): void
     {
         $result = [];
 
@@ -411,7 +388,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_throws_exception_when_data_could_not_be_encoded_to_json()
+    public function it_throws_exception_when_data_could_not_be_encoded_to_json(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Error during json encoding');
@@ -429,7 +406,7 @@ abstract class AbstractJsonProducerTest extends TestCase implements CanCreateCon
     /**
      * @test
      */
-    public function it_throws_exception_when_data_could_not_be_encoded_to_json_2()
+    public function it_throws_exception_when_data_could_not_be_encoded_to_json_2(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Exception during json encoding');

--- a/tests/AbstractPlainProducerTest.php
+++ b/tests/AbstractPlainProducerTest.php
@@ -48,7 +48,7 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
 
     protected function setUp(): void
     {
-        $this->callback = function (Envelope $envelope) {
+        $this->callback = function (Envelope $envelope): void {
             $this->results[] = $envelope->getBody();
         };
 
@@ -128,10 +128,10 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
     public function it_produces_in_confirm_mode(): void
     {
         $this->exchange->getChannel()->setConfirmCallback(
-            function () {
+            function (): bool {
                 return false;
             },
-            function (int $delivery_tag, bool $multiple, bool $requeue) {
+            function (int $delivery_tag, bool $multiple, bool $requeue): void {
                 throw new \Exception('Could not confirm message publishing');
             }
         );

--- a/tests/AbstractPlainProducerTest.php
+++ b/tests/AbstractPlainProducerTest.php
@@ -32,43 +32,19 @@ use HumusTest\Amqp\Helper\CanCreateConnection;
 use HumusTest\Amqp\Helper\DeleteOnTearDownTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class AbstractPlainProducerTest
- * @package HumusTest\Amqp
- */
 abstract class AbstractPlainProducerTest extends TestCase implements CanCreateConnection
 {
     use DeleteOnTearDownTrait;
 
-    /**
-     * @var Channel
-     */
-    protected $channel;
-
-    /**
-     * @var Exchange
-     */
-    protected $exchange;
-
-    /**
-     * @var Queue
-     */
-    protected $queue;
-
-    /**
-     * @var PlainProducer
-     */
-    protected $producer;
-
+    protected Channel $channel;
+    protected Exchange $exchange;
+    protected Queue $queue;
+    protected PlainProducer $producer;
     /**
      * @var callable
      */
     protected $callback;
-
-    /**
-     * @var array
-     */
-    protected $results = [];
+    protected array $results = [];
 
     protected function setUp(): void
     {
@@ -100,7 +76,7 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
     /**
      * @test
      */
-    public function it_produces_and_get_messages_from_queue()
+    public function it_produces_and_get_messages_from_queue(): void
     {
         $producer = new PlainProducer($this->exchange);
         $producer->publish('foo');
@@ -116,7 +92,7 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
     /**
      * @test
      */
-    public function it_produces_transactional_and_get_messages_from_queue()
+    public function it_produces_transactional_and_get_messages_from_queue(): void
     {
         $producer = new PlainProducer($this->exchange);
         $producer->startTransaction();
@@ -134,7 +110,7 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
     /**
      * @test
      */
-    public function it_rolls_back_transaction()
+    public function it_rolls_back_transaction(): void
     {
         $producer = new PlainProducer($this->exchange);
         $producer->startTransaction();
@@ -149,7 +125,7 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
     /**
      * @test
      */
-    public function it_produces_in_confirm_mode()
+    public function it_produces_in_confirm_mode(): void
     {
         $this->exchange->getChannel()->setConfirmCallback(
             function () {

--- a/tests/AbstractPlainProducerTest.php
+++ b/tests/AbstractPlainProducerTest.php
@@ -119,7 +119,7 @@ abstract class AbstractPlainProducerTest extends TestCase implements CanCreateCo
         $producer->rollbackTransaction();
 
         $msg = $this->queue->get(Constants::AMQP_NOPARAM);
-        $this->assertFalse($msg);
+        $this->assertNull($msg);
     }
 
     /**

--- a/tests/AbstractQueueTest.php
+++ b/tests/AbstractQueueTest.php
@@ -190,7 +190,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
 
         $result = [];
         $cnt = 2;
-        $this->queue->consume(function (Envelope $envelope, Queue $queue) use (&$result, &$cnt) {
+        $this->queue->consume(function (Envelope $envelope, Queue $queue) use (&$result, &$cnt): bool {
             $result[] = $envelope->getBody();
             $result[] = $queue->getName();
             $cnt--;

--- a/tests/AbstractQueueTest.php
+++ b/tests/AbstractQueueTest.php
@@ -34,28 +34,13 @@ use HumusTest\Amqp\Helper\CanCreateConnection;
 use HumusTest\Amqp\Helper\DeleteOnTearDownTrait;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class AbstractQueueTest
- * @package HumusTest\Amqp
- */
 abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
 {
     use DeleteOnTearDownTrait;
 
-    /**
-     * @var Channel
-     */
-    protected $channel;
-
-    /**
-     * @var Exchange
-     */
-    protected $exchange;
-
-    /**
-     * @var Queue
-     */
-    protected $queue;
+    protected Channel $channel;
+    protected Exchange $exchange;
+    protected Queue $queue;
 
     protected function setUp(): void
     {
@@ -91,7 +76,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_sets_argument()
+    public function it_sets_argument(): void
     {
         $this->queue->setArgument('key', 'value');
 
@@ -130,7 +115,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_sets_name_flags_and_type()
+    public function it_sets_name_flags_and_type(): void
     {
         $this->assertEquals('test-queue', $this->queue->getName());
 
@@ -151,7 +136,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_binds_with_arguments()
+    public function it_binds_with_arguments(): void
     {
         $this->queue->unbind('test-exchange', '#', [
             'foo' => 'bar',
@@ -181,7 +166,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_unbinds_queue()
+    public function it_unbinds_queue(): void
     {
         $this->queue->unbind('test-exchange');
     }
@@ -189,7 +174,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_returns_channel_and_connection()
+    public function it_returns_channel_and_connection(): void
     {
         $this->assertInstanceOf(Channel::class, $this->queue->getChannel());
         $this->assertInstanceOf(Connection::class, $this->queue->getConnection());
@@ -198,7 +183,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_consumes_with_callback()
+    public function it_consumes_with_callback(): void
     {
         $this->exchange->publish('foo');
         $this->exchange->publish('bar');
@@ -227,7 +212,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_produces_and_get_messages_from_queue()
+    public function it_produces_and_get_messages_from_queue(): void
     {
         $this->exchange->publish('foo', '', Constants::AMQP_NOPARAM, [
             'priority' => 5,
@@ -266,7 +251,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_produces_transactional_and_get_messages_from_queue()
+    public function it_produces_transactional_and_get_messages_from_queue(): void
     {
         $this->channel->startTransaction();
         $this->exchange->publish('foo');
@@ -286,7 +271,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_rolls_back_transation()
+    public function it_rolls_back_transation(): void
     {
         $this->channel->startTransaction();
         $this->exchange->publish('foo');
@@ -300,7 +285,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_purges_messages_from_queue()
+    public function it_purges_messages_from_queue(): void
     {
         $this->channel->startTransaction();
         $this->exchange->publish('foo');
@@ -321,7 +306,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_returns_envelope_information()
+    public function it_returns_envelope_information(): void
     {
         $this->exchange->publish('foo', 'routingKey', Constants::AMQP_NOPARAM, [
             'content_type' => 'text/plain',
@@ -371,7 +356,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_acks()
+    public function it_acks(): void
     {
         $this->exchange->publish('foo');
 
@@ -387,7 +372,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_nacks_and_rejects_message()
+    public function it_nacks_and_rejects_message(): void
     {
         $this->exchange->publish('foo');
 
@@ -410,7 +395,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_cannot_declare_queue_with_reserved_name_prefix()
+    public function it_cannot_declare_queue_with_reserved_name_prefix(): void
     {
         $this->expectException(QueueException::class);
         $this->expectExceptionMessage('ACCESS_REFUSED - queue name \'amq.foo\' contains reserved prefix \'amq.*\'');
@@ -423,7 +408,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_cannot_declare_queue_with_closed_channel()
+    public function it_cannot_declare_queue_with_closed_channel(): void
     {
         $this->expectException(ChannelException::class);
 
@@ -435,7 +420,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_cannot_redeclare_with_other_arguments()
+    public function it_cannot_redeclare_with_other_arguments(): void
     {
         $this->expectException(QueueException::class);
         $this->expectExceptionMessage(
@@ -450,7 +435,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_cannot_access_an_exclusive_queue_from_another_channel()
+    public function it_cannot_access_an_exclusive_queue_from_another_channel(): void
     {
         $this->expectException(QueueException::class);
         $this->expectExceptionMessage(
@@ -497,7 +482,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
     /**
      * @test
      */
-    public function it_throws_exception_in_passive_mode_when_queues_does_not_exist()
+    public function it_throws_exception_in_passive_mode_when_queues_does_not_exist(): void
     {
         $this->expectException(QueueException::class);
         $this->expectExceptionMessage(

--- a/tests/AbstractQueueTest.php
+++ b/tests/AbstractQueueTest.php
@@ -279,7 +279,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
 
         $msg = $this->queue->get(Constants::AMQP_AUTOACK);
 
-        $this->assertFalse($msg);
+        $this->assertNull($msg);
     }
 
     /**
@@ -300,7 +300,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
 
         $msg2 = $this->queue->get(Constants::AMQP_AUTOACK);
 
-        $this->assertFalse($msg2);
+        $this->assertNull($msg2);
     }
 
     /**
@@ -366,7 +366,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
 
         $msg = $this->queue->get(Constants::AMQP_NOPARAM);
 
-        $this->assertFalse($msg);
+        $this->assertNull($msg);
     }
 
     /**
@@ -389,7 +389,7 @@ abstract class AbstractQueueTest extends TestCase implements CanCreateConnection
 
         $msg = $this->queue->get(Constants::AMQP_NOPARAM);
 
-        $this->assertFalse($msg);
+        $this->assertNull($msg);
     }
 
     /**

--- a/tests/AmqpExtension/CallbackConsumerTest.php
+++ b/tests/AmqpExtension/CallbackConsumerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\AmqpExtension;
 use HumusTest\Amqp\AbstractCallbackConsumerTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class CallbackConsumerTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 class CallbackConsumerTest extends AbstractCallbackConsumerTest
 {
     use CreateConnectionTrait;

--- a/tests/AmqpExtension/ChannelRecoverTest.php
+++ b/tests/AmqpExtension/ChannelRecoverTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\AmqpExtension;
 use HumusTest\Amqp\AbstractChannelRecoverTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class ChannelRecoverTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 final class ChannelRecoverTest extends AbstractChannelRecoverTest
 {
     use CreateConnectionTrait;

--- a/tests/AmqpExtension/ChannelTest.php
+++ b/tests/AmqpExtension/ChannelTest.php
@@ -27,10 +27,6 @@ use Humus\Amqp\Driver\AmqpExtension\Connection;
 use HumusTest\Amqp\AbstractChannelTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class ChannelTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 final class ChannelTest extends AbstractChannelTest
 {
     use CreateConnectionTrait;
@@ -47,7 +43,7 @@ final class ChannelTest extends AbstractChannelTest
     /**
      * @test
      */
-    public function it_connects_the_channel()
+    public function it_connects_the_channel(): void
     {
         $this->assertTrue($this->channel->isConnected());
     }
@@ -55,7 +51,7 @@ final class ChannelTest extends AbstractChannelTest
     /**
      * @test
      */
-    public function it_throws_exception_when_cannot_create_channel()
+    public function it_throws_exception_when_cannot_create_channel(): void
     {
         $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Could not create channel. No connection available.');

--- a/tests/AmqpExtension/ConnectionTest.php
+++ b/tests/AmqpExtension/ConnectionTest.php
@@ -128,7 +128,7 @@ final class ConnectionTest extends AbstractConnectionTest
         $options = new ConnectionOptions();
         $options->setVhost('/humus-amqp-test');
         $options->setPort(5671);
-        $options->setCACert(__DIR__ . '/../../provision/test_certs/cacert.pem');
+        $options->setCaCert(__DIR__ . '/../../provision/test_certs/cacert.pem');
         $options->setCert(__DIR__ . '/../../provision/test_certs/cert.pem');
         $options->setKey(__DIR__ . '/../../provision/test_certs/key.pem');
         $options->setVerify(false);
@@ -154,7 +154,7 @@ final class ConnectionTest extends AbstractConnectionTest
 
         $options->setVhost('/humus-amqp-test');
         $options->setPort(5671);
-        $options->setCACert(__DIR__ . '/../../provision/test_certs/cacert.pem');
+        $options->setCaCert(__DIR__ . '/../../provision/test_certs/cacert.pem');
         $options->setVerify(false);
 
         $connection = new Connection($options);

--- a/tests/AmqpExtension/ConnectionTest.php
+++ b/tests/AmqpExtension/ConnectionTest.php
@@ -28,10 +28,6 @@ use Humus\Amqp\Exception\InvalidArgumentException;
 use HumusTest\Amqp\AbstractConnectionTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class ConnectionTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 final class ConnectionTest extends AbstractConnectionTest
 {
     use CreateConnectionTrait;
@@ -46,7 +42,7 @@ final class ConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_credentials()
+    public function it_throws_exception_with_invalid_credentials(): void
     {
         $this->expectException(\Exception::class);
 
@@ -60,7 +56,7 @@ final class ConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_connects_with_valid_credentials()
+    public function it_connects_with_valid_credentials(): void
     {
         $connection = $this->createConnection();
 
@@ -74,7 +70,7 @@ final class ConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_uses_persistent_connection()
+    public function it_uses_persistent_connection(): void
     {
         $connection = $this->createConnection(new ConnectionOptions(['persistent' => true]));
 
@@ -88,7 +84,7 @@ final class ConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_reconnects()
+    public function it_reconnects(): void
     {
         $connection = $this->createConnection();
 
@@ -102,7 +98,7 @@ final class ConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_reconnects_a_persistent_connection()
+    public function it_reconnects_a_persistent_connection(): void
     {
         $connection = $this->createConnection(new ConnectionOptions(['persistent' => true]));
 
@@ -116,7 +112,7 @@ final class ConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_returns_internal_connection()
+    public function it_returns_internal_connection(): void
     {
         $connection = $this->createConnection();
 
@@ -127,7 +123,7 @@ final class ConnectionTest extends AbstractConnectionTest
      * @test
      * @group ssl
      */
-    public function it_connects_with_ssl()
+    public function it_connects_with_ssl(): void
     {
         $options = new ConnectionOptions();
         $options->setVhost('/humus-amqp-test');
@@ -152,7 +148,7 @@ final class ConnectionTest extends AbstractConnectionTest
      * @test
      * @group ssl
      */
-    public function it_connects_with_only_cacert()
+    public function it_connects_with_only_cacert(): void
     {
         $options = new ConnectionOptions();
 
@@ -172,7 +168,7 @@ final class ConnectionTest extends AbstractConnectionTest
      * @test
      * @group ssl
      */
-    public function it_throws_if_cacert_not_set_but_verify_is_set_to_true()
+    public function it_throws_if_cacert_not_set_but_verify_is_set_to_true(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('CA cert not set, so it can\'t be verified.');

--- a/tests/AmqpExtension/ExchangeTest.php
+++ b/tests/AmqpExtension/ExchangeTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\AmqpExtension;
 use HumusTest\Amqp\AbstractExchangeTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class ExchangeTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 final class ExchangeTest extends AbstractExchangeTest
 {
     use CreateConnectionTrait;

--- a/tests/AmqpExtension/Helper/CreateConnectionTrait.php
+++ b/tests/AmqpExtension/Helper/CreateConnectionTrait.php
@@ -25,17 +25,9 @@ namespace HumusTest\Amqp\AmqpExtension\Helper;
 use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Driver\AmqpExtension\Connection;
 
-/**
- * Class CreateConnectionTrait
- * @package HumusTest\Amqp\AmqpExtension\Helper
- */
 trait CreateConnectionTrait
 {
-    /**
-     * @param ConnectionOptions|null $options
-     * @return \Humus\Amqp\Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): \Humus\Amqp\Connection
+    public function createConnection(?ConnectionOptions $options = null): \Humus\Amqp\Connection
     {
         if (null === $options) {
             $options = new ConnectionOptions();

--- a/tests/AmqpExtension/JsonProducerTest.php
+++ b/tests/AmqpExtension/JsonProducerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\AmqpExtension;
 use HumusTest\Amqp\AbstractJsonProducerTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class JsonProducerTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 final class JsonProducerTest extends AbstractJsonProducerTest
 {
     use CreateConnectionTrait;

--- a/tests/AmqpExtension/JsonRpc/JsonRpcClientAndServerTest.php
+++ b/tests/AmqpExtension/JsonRpc/JsonRpcClientAndServerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\AmqpExtension\JsonRpc;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 use HumusTest\Amqp\JsonRpc\AbstractJsonRpcClientAndServerTest;
 
-/**
- * Class JsonRpcJsonRpcClientAndServerTest
- * @package HumusTest\Amqp\AmqpExtension\JsonRpc
- */
 class JsonRpcClientAndServerTest extends AbstractJsonRpcClientAndServerTest
 {
     use CreateConnectionTrait;

--- a/tests/AmqpExtension/PlainProducerTest.php
+++ b/tests/AmqpExtension/PlainProducerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\AmqpExtension;
 use HumusTest\Amqp\AbstractPlainProducerTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class PlainProducerTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 final class PlainProducerTest extends AbstractPlainProducerTest
 {
     use CreateConnectionTrait;

--- a/tests/AmqpExtension/QueueTest.php
+++ b/tests/AmqpExtension/QueueTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\AmqpExtension;
 use HumusTest\Amqp\AbstractQueueTest;
 use HumusTest\Amqp\AmqpExtension\Helper\CreateConnectionTrait;
 
-/**
- * Class QueueTest
- * @package HumusTest\Amqp\AmqpExtension
- */
 final class QueueTest extends AbstractQueueTest
 {
     use CreateConnectionTrait;
@@ -46,7 +42,7 @@ final class QueueTest extends AbstractQueueTest
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_consumes_without_callback()
+    public function it_consumes_without_callback(): void
     {
         $this->exchange->publish('foo');
         $this->exchange->publish('bar');

--- a/tests/Console/Command/PublishMessageCommandTest.php
+++ b/tests/Console/Command/PublishMessageCommandTest.php
@@ -32,16 +32,12 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * Class PublishMessageCommandTest
- * @package HumusTest\Amqp\Console\Command
- */
 class PublishMessageCommandTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_returns_when_invalid_name_given()
+    public function it_returns_when_invalid_name_given(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('invalid-producer')->willReturn(false)->shouldBeCalled();
@@ -56,7 +52,7 @@ class PublishMessageCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_no_name_given()
+    public function it_returns_when_no_name_given(): void
     {
         $tester = $this->createCommandTester($this->prophesize(ContainerInterface::class)->reveal());
         $tester->execute([]);
@@ -68,7 +64,7 @@ class PublishMessageCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_confirm_select_and_transactional_are_set()
+    public function it_returns_when_confirm_select_and_transactional_are_set(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('producer')->willReturn(true)->shouldBeCalled();
@@ -83,7 +79,7 @@ class PublishMessageCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_cannot_decode_arguments()
+    public function it_returns_when_cannot_decode_arguments(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('producer')->willReturn(true)->shouldBeCalled();
@@ -98,7 +94,7 @@ class PublishMessageCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_publishes_with_arguments_and_routing_key_and_flag()
+    public function it_publishes_with_arguments_and_routing_key_and_flag(): void
     {
         $producer = $this->prophesize(Producer::class);
         $producer->publish('test-message', 'test', Constants::AMQP_IMMEDIATE, [
@@ -134,7 +130,7 @@ class PublishMessageCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_publishes_transactional()
+    public function it_publishes_transactional(): void
     {
         $producer = $this->prophesize(Producer::class);
         $producer->startTransaction()->shouldBeCalled();
@@ -155,7 +151,7 @@ class PublishMessageCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_publishes_with_confirm_select()
+    public function it_publishes_with_confirm_select(): void
     {
         $producer = $this->prophesize(Producer::class);
         $producer->confirmSelect()->shouldBeCalled();
@@ -174,11 +170,7 @@ class PublishMessageCommandTest extends TestCase
         $this->assertEquals("Message published\n", $tester->getDisplay(true));
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return CommandTester
-     */
-    private function createCommandTester(ContainerInterface $container)
+    private function createCommandTester(ContainerInterface $container): CommandTester
     {
         $command = new PublishMessageCommand();
         $command->setHelperSet(

--- a/tests/Console/Command/PurgeQueueCommandTest.php
+++ b/tests/Console/Command/PurgeQueueCommandTest.php
@@ -32,16 +32,12 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * Class PurgeQueueCommandTest
- * @package HumusTest\Amqp\Console\Command
- */
 class PurgeQueueCommandTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_returns_when_invalid_name_given()
+    public function it_returns_when_invalid_name_given(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn(
@@ -84,7 +80,7 @@ class PurgeQueueCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_no_name_given()
+    public function it_returns_when_no_name_given(): void
     {
         $tester = $this->createCommandTester($this->prophesize(ContainerInterface::class)->reveal());
         $tester->execute([]);
@@ -96,7 +92,7 @@ class PurgeQueueCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_purges_the_queue()
+    public function it_purges_the_queue(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn(
@@ -156,11 +152,7 @@ class PurgeQueueCommandTest extends TestCase
         );
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return CommandTester
-     */
-    private function createCommandTester(ContainerInterface $container)
+    private function createCommandTester(ContainerInterface $container): CommandTester
     {
         $command = new PurgeQueueCommand();
         $command->setHelperSet(

--- a/tests/Console/Command/SetupFabricCommandTest.php
+++ b/tests/Console/Command/SetupFabricCommandTest.php
@@ -33,16 +33,12 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * Class SetupFabricCommand
- * @package HumusTest\Amqp\Console\Command
- */
 class SetupFabricCommandTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_outputs_that_nothing_is_to_do()
+    public function it_outputs_that_nothing_is_to_do(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn(new \ArrayObject())->shouldBeCalled();
@@ -60,7 +56,7 @@ class SetupFabricCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_declares_exchanges_and_queues()
+    public function it_declares_exchanges_and_queues(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn(
@@ -125,11 +121,7 @@ class SetupFabricCommandTest extends TestCase
         );
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return CommandTester
-     */
-    private function createCommandTester(ContainerInterface $container)
+    private function createCommandTester(ContainerInterface $container): CommandTester
     {
         $command = new SetupFabricCommand();
         $command->setHelperSet(

--- a/tests/Console/Command/ShowCommandTest.php
+++ b/tests/Console/Command/ShowCommandTest.php
@@ -29,16 +29,12 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * Class ShowCommandTest
- * @package HumusTest\Amqp\Console\Command
- */
 class ShowCommandTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_returns_when_invalid_type_given()
+    public function it_returns_when_invalid_type_given(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -52,7 +48,7 @@ class ShowCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_no_name_given()
+    public function it_returns_when_no_name_given(): void
     {
         $tester = $this->createCommandTester($this->prophesize(ContainerInterface::class)->reveal());
         $tester->execute([]);
@@ -65,7 +61,7 @@ class ShowCommandTest extends TestCase
      * @test
      * @dataProvider dataProvider
      */
-    public function it_returns_when_types_not_available(string $type)
+    public function it_returns_when_types_not_available(string $type): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn(new \ArrayObject())->shouldBeCalled();
@@ -80,7 +76,7 @@ class ShowCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_lists_all_types_with_specs()
+    public function it_lists_all_types_with_specs(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->get('config')->willReturn(
@@ -141,11 +137,7 @@ class ShowCommandTest extends TestCase
         $this->assertRegExp('/Producer: demo-producer/', $output);
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return CommandTester
-     */
-    private function createCommandTester(ContainerInterface $container)
+    private function createCommandTester(ContainerInterface $container): CommandTester
     {
         $command = new ShowCommand();
         $command->setHelperSet(
@@ -157,10 +149,7 @@ class ShowCommandTest extends TestCase
         return new CommandTester($command);
     }
 
-    /**
-     * @return array
-     */
-    public function dataProvider()
+    public function dataProvider(): array
     {
         return [
             ['connections'],

--- a/tests/Console/Command/StartCallbackConsumerCommandTest.php
+++ b/tests/Console/Command/StartCallbackConsumerCommandTest.php
@@ -30,16 +30,12 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * Class StartCallbackConsumerCommandTest
- * @package HumusTest\Amqp\Console\Command
- */
 class StartCallbackConsumerCommandTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_starts_the_consumer()
+    public function it_starts_the_consumer(): void
     {
         $server = $this->prophesize(Consumer::class);
         $server->consume(4)->shouldBeCalled();
@@ -58,7 +54,7 @@ class StartCallbackConsumerCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_no_name_given()
+    public function it_returns_when_no_name_given(): void
     {
         $tester = $this->createCommandTester($this->prophesize(ContainerInterface::class)->reveal());
         $tester->execute([]);
@@ -70,7 +66,7 @@ class StartCallbackConsumerCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_consumer_not_found()
+    public function it_returns_when_consumer_not_found(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('unknown')->willReturn(false)->shouldBeCalled();
@@ -82,11 +78,7 @@ class StartCallbackConsumerCommandTest extends TestCase
         $this->assertEquals("No consumer with name unknown found\n", $tester->getDisplay(true));
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return CommandTester
-     */
-    private function createCommandTester(ContainerInterface $container)
+    private function createCommandTester(ContainerInterface $container): CommandTester
     {
         $command = new StartCallbackConsumerCommand();
         $command->setHelperSet(

--- a/tests/Console/Command/StartJsonRpcServerCommandTest.php
+++ b/tests/Console/Command/StartJsonRpcServerCommandTest.php
@@ -30,16 +30,12 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\CommandTester;
 
-/**
- * Class StartJsonRpcServerCommandTest
- * @package HumusTest\Amqp\Console\Command
- */
 class StartJsonRpcServerCommandTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_starts_the_json_rpc_server()
+    public function it_starts_the_json_rpc_server(): void
     {
         $server = $this->prophesize(Consumer::class);
         $server->consume(4)->shouldBeCalled();
@@ -58,7 +54,7 @@ class StartJsonRpcServerCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_no_name_given()
+    public function it_returns_when_no_name_given(): void
     {
         $tester = $this->createCommandTester($this->prophesize(ContainerInterface::class)->reveal());
         $tester->execute([]);
@@ -70,7 +66,7 @@ class StartJsonRpcServerCommandTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_when_json_rpc_server_not_found()
+    public function it_returns_when_json_rpc_server_not_found(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $container->has('unknown_server')->willReturn(false)->shouldBeCalled();
@@ -82,11 +78,7 @@ class StartJsonRpcServerCommandTest extends TestCase
         $this->assertEquals("No JSON-RPC server with name unknown_server found\n", $tester->getDisplay(true));
     }
 
-    /**
-     * @param ContainerInterface $container
-     * @return CommandTester
-     */
-    private function createCommandTester(ContainerInterface $container)
+    private function createCommandTester(ContainerInterface $container): CommandTester
     {
         $command = new StartJsonRpcServerCommand();
         $command->setHelperSet(

--- a/tests/Console/ConsumerRunnerTest.php
+++ b/tests/Console/ConsumerRunnerTest.php
@@ -29,16 +29,12 @@ use Psr\Container\ContainerInterface;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Tester\ApplicationTester;
 
-/**
- * Class ConsumerRunnerTest
- * @package HumusTest\Amqp\Console
- */
 class ConsumerRunnerTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_helper_set()
+    public function it_creates_helper_set(): void
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
 
@@ -52,7 +48,7 @@ class ConsumerRunnerTest extends TestCase
     /**
      * @test
      */
-    public function it_prints_cli_config_template()
+    public function it_prints_cli_config_template(): void
     {
         ob_start();
         ConsoleRunner::printCliConfigTemplate();
@@ -65,7 +61,7 @@ class ConsumerRunnerTest extends TestCase
      * @test
      * @backupGlobals
      */
-    public function it_runs_application()
+    public function it_runs_application(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 

--- a/tests/Console/Helper/ContainerHelperTest.php
+++ b/tests/Console/Helper/ContainerHelperTest.php
@@ -26,16 +26,12 @@ use Humus\Amqp\Console\Helper\ContainerHelper;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class ContainerHelperTest
- * @package HumusTest\Amqp\Console\Helper
- */
 class ContainerHelperTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_gets_container()
+    public function it_gets_container(): void
     {
         $container = $this->prophesize(ContainerInterface::class)->reveal();
 

--- a/tests/Container/CallbackConsumerFactoryTest.php
+++ b/tests/Container/CallbackConsumerFactoryTest.php
@@ -92,7 +92,7 @@ class CallbackConsumerFactoryTest extends TestCase
         $connection = $this->prophesize(Connection::class);
         $connection->newChannel()->willReturn($channel->reveal())->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection->reveal())->shouldBeCalled();
-        $container->get('my_callback')->willReturn(function () {
+        $container->get('my_callback')->willReturn(function (): void {
         })->shouldBeCalled();
 
         $factory = new CallbackConsumerFactory('my_consumer');
@@ -161,11 +161,11 @@ class CallbackConsumerFactoryTest extends TestCase
         $connection = $this->prophesize(Connection::class);
         $connection->newChannel()->willReturn($channel->reveal())->shouldBeCalled();
         $container->get('my_connection')->willReturn($connection->reveal())->shouldBeCalled();
-        $container->get('my_callback')->willReturn(function () {
+        $container->get('my_callback')->willReturn(function (): void {
         })->shouldBeCalled();
-        $container->get('my_flush')->willReturn(function () {
+        $container->get('my_flush')->willReturn(function (): void {
         })->shouldBeCalled();
-        $container->get('my_error')->willReturn(function () {
+        $container->get('my_error')->willReturn(function (): void {
         })->shouldBeCalled();
         $container->get('my_logger')->willReturn($logger->reveal())->shouldBeCalled();
 

--- a/tests/Container/CallbackConsumerFactoryTest.php
+++ b/tests/Container/CallbackConsumerFactoryTest.php
@@ -31,16 +31,12 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
-/**
- * Class CallbackConsumerFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class CallbackConsumerFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_callback_consumer()
+    public function it_creates_callback_consumer(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -108,7 +104,7 @@ class CallbackConsumerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_callback_consumer_with_call_static_and_defined_logger_delivery_and_flush_callback()
+    public function it_creates_callback_consumer_with_call_static_and_defined_logger_delivery_and_flush_callback(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $logger = $this->prophesize(LoggerInterface::class);
@@ -182,7 +178,7 @@ class CallbackConsumerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_container_param()
+    public function it_throws_exception_with_invalid_call_static_container_param(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type Psr\Container\ContainerInterface');

--- a/tests/Container/ConnectionFactoryTest.php
+++ b/tests/Container/ConnectionFactoryTest.php
@@ -31,16 +31,12 @@ use Humus\Amqp\Driver\PhpAmqpLib\StreamConnection;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class ConnectionFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class ConnectionFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_amqp_extension_connection()
+    public function it_creates_amqp_extension_connection(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');
@@ -71,7 +67,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_amqp_extension_connection_with_call_static()
+    public function it_creates_amqp_extension_connection_with_call_static(): void
     {
         if (! extension_loaded('amqp')) {
             $this->markTestSkipped('php amqp extension not loaded');
@@ -102,7 +98,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_php_amqplib_lazy_connection()
+    public function it_creates_php_amqplib_lazy_connection(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -130,7 +126,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_php_amqplib_socket_connection()
+    public function it_creates_php_amqplib_socket_connection(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -158,7 +154,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_php_amqplib_stream_connection()
+    public function it_creates_php_amqplib_stream_connection(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -187,7 +183,7 @@ class ConnectionFactoryTest extends TestCase
      * @test
      * @group ssl
      */
-    public function it_creates_php_amqplib_ssl_connection()
+    public function it_creates_php_amqplib_ssl_connection(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -221,7 +217,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_during_php_amqplib_connection_creation_when_type_is_missing()
+    public function it_throws_exception_during_php_amqplib_connection_creation_when_type_is_missing(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('For php-amqplib driver a connection type is required');
@@ -249,7 +245,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_during_php_amqplib_connection_creation_when_invalid_type_given()
+    public function it_throws_exception_during_php_amqplib_connection_creation_when_invalid_type_given(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid connection type for php-amqplib driver given');
@@ -278,7 +274,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_container_param()
+    public function it_throws_exception_with_invalid_call_static_container_param(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type Psr\Container\ContainerInterface');
@@ -290,7 +286,7 @@ class ConnectionFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_driver_registered()
+    public function it_throws_exception_when_no_driver_registered(): void
     {
         $this->expectException(\Humus\Amqp\Exception\RuntimeException::class);
         $this->expectExceptionMessage('No driver factory registered in container');

--- a/tests/Container/DriverFactoryTest.php
+++ b/tests/Container/DriverFactoryTest.php
@@ -27,16 +27,12 @@ use Humus\Amqp\Driver\Driver;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class DriverFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class DriverFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_returns_amqp_extension_driver()
+    public function it_returns_amqp_extension_driver(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -58,7 +54,7 @@ class DriverFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_returns_php_amqplib_driver()
+    public function it_returns_php_amqplib_driver(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 

--- a/tests/Container/ExchangeFactoryTest.php
+++ b/tests/Container/ExchangeFactoryTest.php
@@ -30,16 +30,12 @@ use Humus\Amqp\Exchange;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class ExchangeFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class ExchangeFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_exchange()
+    public function it_creates_exchange(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -84,7 +80,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_exchange_with_call_static()
+    public function it_creates_exchange_with_call_static(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -129,7 +125,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_exchange_with_call_static_and_given_channel()
+    public function it_creates_exchange_with_call_static_and_given_channel(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -164,7 +160,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_container_param()
+    public function it_throws_exception_with_invalid_call_static_container_param(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type Psr\Container\ContainerInterface');
@@ -176,7 +172,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_channel_param()
+    public function it_throws_exception_with_invalid_call_static_channel_param(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The second argument must be a type of Humus\Amqp\Channel or null');
@@ -190,7 +186,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_auto_declares_exchange()
+    public function it_auto_declares_exchange(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -237,7 +233,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_auto_declares_exchange_and_binds_exchange_to_exchange()
+    public function it_auto_declares_exchange_and_binds_exchange_to_exchange(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -355,7 +351,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_auto_declares_alternate_exchange()
+    public function it_auto_declares_alternate_exchange(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -419,7 +415,7 @@ class ExchangeFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_bool_given_to_call_static_as_third_parameter()
+    public function it_throws_exception_when_no_bool_given_to_call_static_as_third_parameter(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The third argument must be a boolean');

--- a/tests/Container/JsonRpcClientFactoryTest.php
+++ b/tests/Container/JsonRpcClientFactoryTest.php
@@ -32,16 +32,12 @@ use Humus\Amqp\Queue;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class JsonRpcClientFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class JsonRpcClientFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_json_rpc_client()
+    public function it_creates_json_rpc_client(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -112,7 +108,7 @@ class JsonRpcClientFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_json_rpc_client_with_custom_error_factory()
+    public function it_creates_json_rpc_client_with_custom_error_factory(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -187,7 +183,7 @@ class JsonRpcClientFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_json_rpc_client_with_call_static()
+    public function it_creates_json_rpc_client_with_call_static(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -262,7 +258,7 @@ class JsonRpcClientFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_container_param()
+    public function it_throws_exception_with_invalid_call_static_container_param(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type Psr\Container\ContainerInterface');

--- a/tests/Container/JsonRpcServerFactoryTest.php
+++ b/tests/Container/JsonRpcServerFactoryTest.php
@@ -98,7 +98,7 @@ class JsonRpcServerFactoryTest extends TestCase
         $connection->newChannel()->willReturn($channel->reveal());
 
         $container->get('my_connection')->willReturn($connection->reveal());
-        $container->get('my_callback')->willReturn(function () {
+        $container->get('my_callback')->willReturn(function (): void {
         });
 
         $factory = new JsonRpcServerFactory('my_server');
@@ -172,7 +172,7 @@ class JsonRpcServerFactoryTest extends TestCase
         $connection->newChannel()->willReturn($channel->reveal());
 
         $container->get('my_connection')->willReturn($connection->reveal());
-        $container->get('my_callback')->willReturn(function () {
+        $container->get('my_callback')->willReturn(function (): void {
         });
         $container->get('my_logger')->willReturn($logger->reveal())->shouldBeCalled();
 
@@ -246,7 +246,7 @@ class JsonRpcServerFactoryTest extends TestCase
         $connection->newChannel()->willReturn($channel->reveal());
 
         $container->get('my_connection')->willReturn($connection->reveal());
-        $container->get('my_callback')->willReturn(function () {
+        $container->get('my_callback')->willReturn(function (): void {
         });
 
         $errorFactory = $this->prophesize(ErrorFactory::class);

--- a/tests/Container/JsonRpcServerFactoryTest.php
+++ b/tests/Container/JsonRpcServerFactoryTest.php
@@ -33,16 +33,12 @@ use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 
-/**
- * Class JsonRpcServerFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class JsonRpcServerFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_json_rpc_server()
+    public function it_creates_json_rpc_server(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -114,7 +110,7 @@ class JsonRpcServerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_json_rpc_server_with_call_static_and_defined_logger()
+    public function it_creates_json_rpc_server_with_call_static_and_defined_logger(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
         $logger = $this->prophesize(LoggerInterface::class);
@@ -189,7 +185,7 @@ class JsonRpcServerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_json_rpc_server_with_call_static_and_defined_error_factory()
+    public function it_creates_json_rpc_server_with_call_static_and_defined_error_factory(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -265,7 +261,7 @@ class JsonRpcServerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_container_param()
+    public function it_throws_exception_with_invalid_call_static_container_param(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type Psr\Container\ContainerInterface');

--- a/tests/Container/ProducerFactoryTest.php
+++ b/tests/Container/ProducerFactoryTest.php
@@ -31,16 +31,12 @@ use Humus\Amqp\PlainProducer;
 use PHPUnit\Framework\TestCase;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class ProducerFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class ProducerFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_plain_producer()
+    public function it_creates_plain_producer(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -87,7 +83,7 @@ class ProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_json_producer()
+    public function it_creates_json_producer(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -134,7 +130,7 @@ class ProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_producer_with_call_static()
+    public function it_creates_producer_with_call_static(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -181,7 +177,7 @@ class ProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_container_param()
+    public function it_throws_exception_with_invalid_call_static_container_param(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type Psr\Container\ContainerInterface');
@@ -193,7 +189,7 @@ class ProducerFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_producer_type_given()
+    public function it_throws_exception_with_invalid_producer_type_given(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Unknown producer type invalid requested');

--- a/tests/Container/QueueFactoryTest.php
+++ b/tests/Container/QueueFactoryTest.php
@@ -32,16 +32,12 @@ use PHPUnit\Framework\TestCase;
 use Prophecy\Argument;
 use Psr\Container\ContainerInterface;
 
-/**
- * Class QueueFactoryTest
- * @package HumusTest\Amqp\Container
- */
 class QueueFactoryTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_creates_queue()
+    public function it_creates_queue(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -96,7 +92,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_queue_with_call_static()
+    public function it_creates_queue_with_call_static(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -151,7 +147,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_queue_with_call_static_and_given_channel()
+    public function it_creates_queue_with_call_static_and_given_channel(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -196,7 +192,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_container_param()
+    public function it_throws_exception_with_invalid_call_static_container_param(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The first argument must be of type Psr\Container\ContainerInterface');
@@ -208,7 +204,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_call_static_channel_param()
+    public function it_throws_exception_with_invalid_call_static_channel_param(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The second argument must be a type of Humus\Amqp\Channel or null');
@@ -222,7 +218,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_auto_declares_exchange()
+    public function it_auto_declares_exchange(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -290,7 +286,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_auto_declares_exchange_as_iterator()
+    public function it_auto_declares_exchange_as_iterator(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -358,7 +354,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_during_auto_declare_with_empty_exchanges()
+    public function it_throws_exception_during_auto_declare_with_empty_exchanges(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Expected an array or traversable of exchange');
@@ -415,7 +411,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_auto_declares_exchange_with_routing_key_and_bind_arguments()
+    public function it_auto_declares_exchange_with_routing_key_and_bind_arguments(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -494,7 +490,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_auto_declares_dead_letter_exchange()
+    public function it_auto_declares_dead_letter_exchange(): void
     {
         $container = $this->prophesize(ContainerInterface::class);
 
@@ -575,7 +571,7 @@ class QueueFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_no_bool_given_to_call_static_as_third_parameter()
+    public function it_throws_exception_when_no_bool_given_to_call_static_as_third_parameter(): void
     {
         $this->expectException(Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('The third argument must be a boolean');

--- a/tests/Helper/CanCreateConnection.php
+++ b/tests/Helper/CanCreateConnection.php
@@ -24,15 +24,7 @@ namespace HumusTest\Amqp\Helper;
 
 use Humus\Amqp\ConnectionOptions;
 
-/**
- * Class CanCreateConnection
- * @package HumusTest\Amqp\Helper
- */
 interface CanCreateConnection
 {
-    /**
-     * @param ConnectionOptions|null $options
-     * @return \Humus\Amqp\Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): \Humus\Amqp\Connection;
+    public function createConnection(?ConnectionOptions $options = null): \Humus\Amqp\Connection;
 }

--- a/tests/Helper/DeleteOnTearDownTrait.php
+++ b/tests/Helper/DeleteOnTearDownTrait.php
@@ -25,16 +25,12 @@ namespace HumusTest\Amqp\Helper;
 use Humus\Amqp\Exchange;
 use Humus\Amqp\Queue;
 
-/**
- * Class DeleteOnTearDownTrait
- * @package HumusTest\Amqp\Helper
- */
 trait DeleteOnTearDownTrait
 {
     /**
      * @var Exchange[]|Queue[]
      */
-    protected $toCleanUp = [];
+    protected array $toCleanUp = [];
 
     protected function tearDown(): void
     {

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -107,7 +107,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
         $server->consume(2);
 
-        $responses = $client->getResponseCollection(2);
+        $responses = $client->getResponseCollection();
 
         $this->assertCount(2, $responses);
 
@@ -784,11 +784,8 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
      */
     public function it_throws_exception_on_client_when_data_could_not_be_encoded_to_json(): void
     {
-        $this->expectException(InvalidArgumentException::class);
-        $this->expectExceptionMessage('Error during json encoding');
-
         $options = $this->prophesize(ConnectionOptions::class);
-        $options->getLogin()->willReturn('user123')->shouldBeCalled();
+        $options->login()->willReturn('user123')->shouldBeCalled();
 
         $connection = $this->prophesize(Connection::class);
         $connection->getOptions()->willReturn($options->reveal())->shouldBeCalled();
@@ -800,6 +797,8 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $exchane = $this->prophesize(Exchange::class);
 
         $client = new JsonRpcClient($queue->reveal(), ['rpc-server' => $exchane->reveal()]);
+
+        $this->expectException(\JsonException::class);
 
         $client->addRequest(new JsonRpcRequest(
             'rpc-server',

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -98,7 +98,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $client->addRequest($request1);
         $client->addRequest($request2);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): JsonRpcResponse {
             return JsonRpcResponse::withResult($request->id(), $request->params() * 2);
         };
 
@@ -108,7 +108,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $server->consume(2);
 
         $responses = $client->getResponseCollection();
-
+die('fdssd');
         $this->assertCount(2, $responses);
 
         $response1 = $responses->getResponse('request-1');
@@ -183,7 +183,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $client->addRequest($request1);
         $client->addRequest($request2);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): void {
         };
 
         $server = new JsonRpcServer($serverQueue, $callback, new NullLogger(), 1.0);
@@ -244,7 +244,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $client->addRequest($request1);
         $client->addRequest($request2);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): void {
         };
 
         $server = new JsonRpcServer($serverQueue, $callback, new NullLogger(), 1.0);
@@ -306,7 +306,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $client->addRequest($request1);
         $client->addRequest($request2);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): void {
         };
 
         $server = new JsonRpcServer($serverQueue, $callback, new NullLogger(), 1.0);
@@ -368,7 +368,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $client->addRequest($request1);
         $client->addRequest($request2);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): int {
             $params = $request->params();
             if (1 == $params) {
                 throw new \Exception('invalid body');
@@ -463,7 +463,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $client->addRequest($request1);
         $client->addRequest($request2);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): JsonRpcResponse {
             return JsonRpcResponse::withResult($request->id(), $request->params() * 2);
         };
 
@@ -525,7 +525,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $client->addRequest($request1);
         $client->addRequest($request2);
 
-        $callback = function (Envelope $envelope) {
+        $callback = function (Envelope $envelope): int {
             return $envelope->getBody() * 2;
         };
 
@@ -692,7 +692,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
         $reflectionProperty2->setAccessible(true);
         $reflectionProperty2->setValue($client, 9);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): JsonRpcResponse {
             if ('time2' === $request->method()) {
                 return JsonRpcResponse::withResult($request->id(), $request->params() * 2);
             }
@@ -851,7 +851,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
         $client->addRequest($request1);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): JsonRpcResponse {
             return JsonRpcResponse::withResult($request->id(), "\xB1\x31");
         };
 
@@ -913,7 +913,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
         $client->addRequest($request1);
 
-        $callback = function (Request $request) {
+        $callback = function (Request $request): void {
             throw new \Exception('foo');
         };
 

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -633,7 +633,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
             'correlation_id' => 'request-3',
             'type' => 'time2',
             'reply_to' => $clientQueue->getName(),
-            'user_id' => $clientQueue->getConnection()->getOptions()->getLogin(),
+            'user_id' => $clientQueue->getConnection()->getOptions()->login(),
             'headers' => [
                 'jsonrpc' => JsonRpcRequest::JSONRPC_VERSION,
             ],
@@ -646,7 +646,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
             'correlation_id' => 'request-4',
             'type' => 'time2',
             'reply_to' => $clientQueue->getName(),
-            'user_id' => $clientQueue->getConnection()->getOptions()->getLogin(),
+            'user_id' => $clientQueue->getConnection()->getOptions()->login(),
         ]);
 
         $serverExchange->publish('2', '', Constants::AMQP_NOPARAM, [
@@ -655,7 +655,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
             'type' => 'time2',
             'correlation_id' => 'request-5',
             'reply_to' => $clientQueue->getName(),
-            'user_id' => $clientQueue->getConnection()->getOptions()->getLogin(),
+            'user_id' => $clientQueue->getConnection()->getOptions()->login(),
             'headers' => [
                 'jsonrpc' => JsonRpcRequest::JSONRPC_VERSION,
             ],
@@ -667,7 +667,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
             'type' => 'time2',
             'correlation_id' => 'request-6',
             'reply_to' => $clientQueue->getName(),
-            'user_id' => $clientQueue->getConnection()->getOptions()->getLogin(),
+            'user_id' => $clientQueue->getConnection()->getOptions()->login(),
             'headers' => [
                 'jsonrpc' => JsonRpcRequest::JSONRPC_VERSION,
             ],

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -42,18 +42,11 @@ use HumusTest\Amqp\TestAsset\ArrayLogger;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
-/**
- * Class AbstractJsonRpcClientAndServerTest
- * @package HumusTest\Amqp\JsonRpc
- */
 abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements CanCreateConnection
 {
     use DeleteOnTearDownTrait;
 
-    /**
-     * @var JsonRpcErrorFactory
-     */
-    private $errorFactory;
+    private JsonRpcErrorFactory $errorFactory;
 
     protected function setUp(): void
     {
@@ -63,7 +56,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_sends_requests_and_server_responds()
+    public function it_sends_requests_and_server_responds(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -148,7 +141,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_sends_shutdown_notifications()
+    public function it_sends_shutdown_notifications(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -209,7 +202,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_responds_to_invalid_notifications()
+    public function it_responds_to_invalid_notifications(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -271,7 +264,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_responds_to_request_without_id_with_error()
+    public function it_responds_to_request_without_id_with_error(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -333,7 +326,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_sends_requests_and_server_responds_and_handles_exception()
+    public function it_sends_requests_and_server_responds_and_handles_exception(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -428,7 +421,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_sends_requests_and_server_times_out()
+    public function it_sends_requests_and_server_times_out(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -490,7 +483,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_sends_ttl_requests_and_server_responds_late()
+    public function it_sends_ttl_requests_and_server_responds_late(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -555,7 +548,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_throws_exception_when_invalid_server_name_given_to_request()
+    public function it_throws_exception_when_invalid_server_name_given_to_request(): void
     {
         $this->expectException(\Humus\Amqp\Exception\InvalidArgumentException::class);
         $this->expectExceptionMessage('Invalid server given, no related exchange "invalid-rpc-server" found.');
@@ -591,7 +584,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_handles_invalid_requests_and_responses()
+    public function it_handles_invalid_requests_and_responses(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -789,7 +782,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_throws_exception_on_client_when_data_could_not_be_encoded_to_json()
+    public function it_throws_exception_on_client_when_data_could_not_be_encoded_to_json(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Error during json encoding');
@@ -818,7 +811,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_returns_error_on_server_when_data_could_not_be_encoded_to_json()
+    public function it_returns_error_on_server_when_data_could_not_be_encoded_to_json(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
@@ -880,7 +873,7 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
     /**
      * @test
      */
-    public function it_returns_trace_when_enabled()
+    public function it_returns_trace_when_enabled(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -107,8 +107,8 @@ abstract class AbstractJsonRpcClientAndServerTest extends TestCase implements Ca
 
         $server->consume(2);
 
-        $responses = $client->getResponseCollection();
-die('fdssd');
+        $responses = $client->getResponseCollection(2);
+
         $this->assertCount(2, $responses);
 
         $response1 = $responses->getResponse('request-1');

--- a/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
+++ b/tests/JsonRpc/AbstractJsonRpcClientAndServerTest.php
@@ -26,7 +26,6 @@ use Humus\Amqp\Connection;
 use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Constants;
 use Humus\Amqp\Envelope;
-use Humus\Amqp\Exception\InvalidArgumentException;
 use Humus\Amqp\Exchange;
 use Humus\Amqp\JsonRpc\JsonRpcClient;
 use Humus\Amqp\JsonRpc\JsonRpcError;

--- a/tests/JsonRpc/JsonRpcErrorFactoryTest.php
+++ b/tests/JsonRpc/JsonRpcErrorFactoryTest.php
@@ -27,15 +27,10 @@ use Humus\Amqp\JsonRpc\Error;
 use Humus\Amqp\JsonRpc\JsonRpcErrorFactory;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class ResponseTest
- * @package HumusTest\Amqp\JsonRpc
- */
 class JsonRpcErrorFactoryTest extends TestCase
 {
-    private $factory;
-
-    private $customMessages = [
+    private ?JsonRpcErrorFactory $factory = null;
+    private array $customMessages = [
         -32000 => 'upper message test',
         -32099 => 'lower message test',
     ];
@@ -49,7 +44,7 @@ class JsonRpcErrorFactoryTest extends TestCase
      * @test
      * @dataProvider predefinedCodeDataProvider
      */
-    public function it_creates_valid_predefined_error(int $code, string $message, $data = null)
+    public function it_creates_valid_predefined_error(int $code, string $message, $data = null): void
     {
         $error = $this->factory->create($code, null, $data);
 
@@ -64,7 +59,7 @@ class JsonRpcErrorFactoryTest extends TestCase
      * @test
      * @dataProvider customCodeDataProvider
      */
-    public function it_creates_valid_custom_error(int $code, string $message, $data = null)
+    public function it_creates_valid_custom_error(int $code, string $message, $data = null): void
     {
         $error = $this->factory->create($code, null, $data);
 
@@ -78,7 +73,7 @@ class JsonRpcErrorFactoryTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_for_invalid_code()
+    public function it_throws_exception_for_invalid_code(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->factory->create(-1);

--- a/tests/JsonRpc/RequestTest.php
+++ b/tests/JsonRpc/RequestTest.php
@@ -26,16 +26,12 @@ use Humus\Amqp\Exception\InvalidArgumentException;
 use Humus\Amqp\JsonRpc\JsonRpcRequest;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class RequestTest
- * @package HumusTest\Amqp\JsonRpc
- */
 class RequestTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_throws_exception_when_invalid_payload_given()
+    public function it_throws_exception_when_invalid_payload_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Params must be of type array, scalar or null');

--- a/tests/JsonRpc/ResponseCollectionTest.php
+++ b/tests/JsonRpc/ResponseCollectionTest.php
@@ -26,16 +26,12 @@ use Humus\Amqp\JsonRpc\JsonRpcResponse;
 use Humus\Amqp\JsonRpc\JsonRpcResponseCollection;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class ResponseCollectionTest
- * @package HumusTest\Amqp\JsonRpc
- */
 class ResponseCollectionTest extends TestCase
 {
     /**
      * @test
      */
-    public function it_iterates_and_accesses_correctly()
+    public function it_iterates_and_accesses_correctly(): void
     {
         $responseCollection = new JsonRpcResponseCollection();
         $responseCollection->addResponse(JsonRpcResponse::withResult('id1', ['foo' => 'bar']));
@@ -62,7 +58,7 @@ class ResponseCollectionTest extends TestCase
     /**
      * @test
      */
-    public function it_iterates_and_accesses_correctly_without_results()
+    public function it_iterates_and_accesses_correctly_without_results(): void
     {
         $responseCollection = new JsonRpcResponseCollection();
 

--- a/tests/JsonRpc/ResponseTest.php
+++ b/tests/JsonRpc/ResponseTest.php
@@ -28,13 +28,9 @@ use Humus\Amqp\JsonRpc\JsonRpcErrorFactory;
 use Humus\Amqp\JsonRpc\JsonRpcResponse;
 use PHPUnit\Framework\TestCase;
 
-/**
- * Class ResponseTest
- * @package HumusTest\Amqp\JsonRpc
- */
 class ResponseTest extends TestCase
 {
-    private $errorFactory;
+    private ?JsonRpcErrorFactory $errorFactory = null;
 
     protected function setUp(): void
     {
@@ -44,7 +40,7 @@ class ResponseTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_valid_result()
+    public function it_creates_valid_result(): void
     {
         $response = JsonRpcResponse::withResult('id', ['foo' => 'bar']);
         $this->assertEquals(['foo' => 'bar'], $response->result());
@@ -54,7 +50,7 @@ class ResponseTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_valid_error()
+    public function it_creates_valid_error(): void
     {
         $response = JsonRpcResponse::withError('id', $this->errorFactory->create(JsonRpcError::ERROR_CODE_32603));
         $this->assertInstanceOf(JsonRpcError::class, $response->error());
@@ -67,7 +63,7 @@ class ResponseTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_valid_error_with_data()
+    public function it_creates_valid_error_with_data(): void
     {
         $response = JsonRpcResponse::withError('id', $this->errorFactory->create(JsonRpcError::ERROR_CODE_32603, null, ['foo' => 'bar']));
         $this->assertInstanceOf(JsonRpcError::class, $response->error());
@@ -80,7 +76,7 @@ class ResponseTest extends TestCase
     /**
      * @test
      */
-    public function it_creates_valid_error_with_custom_message()
+    public function it_creates_valid_error_with_custom_message(): void
     {
         $response = JsonRpcResponse::withError('id', $this->errorFactory->create(JsonRpcError::ERROR_CODE_32603, 'custom message'));
         $this->assertInstanceOf(JsonRpcError::class, $response->error());
@@ -92,7 +88,7 @@ class ResponseTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_invalid_result_given()
+    public function it_throws_exception_when_invalid_result_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('result must only contain arrays and scalar values');
@@ -103,7 +99,7 @@ class ResponseTest extends TestCase
     /**
      * @test
      */
-    public function it_throws_exception_when_invalid_sub_result_given()
+    public function it_throws_exception_when_invalid_sub_result_given(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('result must only contain arrays and scalar values');

--- a/tests/PhpAmqpLib/CallbackConsumerTest.php
+++ b/tests/PhpAmqpLib/CallbackConsumerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\PhpAmqpLib;
 use HumusTest\Amqp\AbstractCallbackConsumerTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class CallbackConsumerTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 class CallbackConsumerTest extends AbstractCallbackConsumerTest
 {
     use CreateConnectionTrait;

--- a/tests/PhpAmqpLib/ChannelRecoverTest.php
+++ b/tests/PhpAmqpLib/ChannelRecoverTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\PhpAmqpLib;
 use HumusTest\Amqp\AbstractChannelRecoverTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class ChannelRecoverTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class ChannelRecoverTest extends AbstractChannelRecoverTest
 {
     use CreateConnectionTrait;

--- a/tests/PhpAmqpLib/ChannelTest.php
+++ b/tests/PhpAmqpLib/ChannelTest.php
@@ -26,10 +26,6 @@ use Humus\Amqp\Exception\BadMethodCallException;
 use HumusTest\Amqp\AbstractChannelTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class ChannelTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class ChannelTest extends AbstractChannelTest
 {
     use CreateConnectionTrait;
@@ -37,7 +33,7 @@ final class ChannelTest extends AbstractChannelTest
     /**
      * @test
      */
-    public function it_throws_exception_on_isConnected()
+    public function it_throws_exception_on_isConnected(): void
     {
         $this->expectException(BadMethodCallException::class);
 

--- a/tests/PhpAmqpLib/ExchangeTest.php
+++ b/tests/PhpAmqpLib/ExchangeTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\PhpAmqpLib;
 use HumusTest\Amqp\AbstractExchangeTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class ExchangeTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class ExchangeTest extends AbstractExchangeTest
 {
     use CreateConnectionTrait;

--- a/tests/PhpAmqpLib/Helper/CreateConnectionTrait.php
+++ b/tests/PhpAmqpLib/Helper/CreateConnectionTrait.php
@@ -25,17 +25,9 @@ namespace HumusTest\Amqp\PhpAmqpLib\Helper;
 use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Driver\PhpAmqpLib\SocketConnection;
 
-/**
- * Class CreateConnectionTrait
- * @package HumusTest\Amqp\PhpAmqpLib\Helper
- */
 trait CreateConnectionTrait
 {
-    /**
-     * @param ConnectionOptions|null $options
-     * @return \Humus\Amqp\Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): \Humus\Amqp\Connection
+    public function createConnection(?ConnectionOptions $options = null): \Humus\Amqp\Connection
     {
         if (null === $options) {
             $options = new ConnectionOptions();

--- a/tests/PhpAmqpLib/JsonProducerTest.php
+++ b/tests/PhpAmqpLib/JsonProducerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\PhpAmqpLib;
 use HumusTest\Amqp\AbstractJsonProducerTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class JsonProducerTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class JsonProducerTest extends AbstractJsonProducerTest
 {
     use CreateConnectionTrait;

--- a/tests/PhpAmqpLib/JsonRpc/JsonRpcClientAndServerTest.php
+++ b/tests/PhpAmqpLib/JsonRpc/JsonRpcClientAndServerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\PhpAmqpLib\JsonRpc;
 use HumusTest\Amqp\JsonRpc\AbstractJsonRpcClientAndServerTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class JsonRpcJsonRpcClientAndServerTest
- * @package HumusTest\Amqp\PhpAmqpLib\JsonRpc
- */
 class JsonRpcClientAndServerTest extends AbstractJsonRpcClientAndServerTest
 {
     use CreateConnectionTrait;

--- a/tests/PhpAmqpLib/LazyConnectionTest.php
+++ b/tests/PhpAmqpLib/LazyConnectionTest.php
@@ -26,27 +26,19 @@ use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Driver\PhpAmqpLib\LazyConnection;
 use HumusTest\Amqp\AbstractConnectionTest;
 
-/**
- * Class LazyConnectionTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class LazyConnectionTest extends AbstractConnectionTest
 {
     /**
      * @test
      */
-    public function it_returns_internal_connection()
+    public function it_returns_internal_connection(): void
     {
         $connection = $this->createConnection();
 
         $this->assertInstanceOf(\PhpAmqpLib\Connection\AMQPLazyConnection::class, $connection->getResource());
     }
 
-    /**
-     * @param ConnectionOptions|null $options
-     * @return \Humus\Amqp\Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): \Humus\Amqp\Connection
+    public function createConnection(?ConnectionOptions $options = null): \Humus\Amqp\Connection
     {
         if (null === $options) {
             $options = new ConnectionOptions();

--- a/tests/PhpAmqpLib/LazySocketConnectionTest.php
+++ b/tests/PhpAmqpLib/LazySocketConnectionTest.php
@@ -27,16 +27,12 @@ use Humus\Amqp\Driver\PhpAmqpLib\Channel;
 use Humus\Amqp\Driver\PhpAmqpLib\LazySocketConnection;
 use HumusTest\Amqp\AbstractConnectionTest;
 
-/**
- * Class LazySocketConnectionTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class LazySocketConnectionTest extends AbstractConnectionTest
 {
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_credentials()
+    public function it_throws_exception_with_invalid_credentials(): void
     {
         $this->expectException(\Exception::class);
 
@@ -47,7 +43,7 @@ final class LazySocketConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_connects_with_valid_credentials()
+    public function it_connects_with_valid_credentials(): void
     {
         $connection = $this->createConnection();
 
@@ -57,7 +53,7 @@ final class LazySocketConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_returns_internal_connection()
+    public function it_returns_internal_connection(): void
     {
         $connection = $this->createConnection();
 
@@ -67,18 +63,14 @@ final class LazySocketConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_connects_and_createss_new_channel()
+    public function it_connects_and_createss_new_channel(): void
     {
         $connection = $this->createConnection();
         $channel = $connection->newChannel();
         $this->assertInstanceOf(Channel::class, $channel);
     }
 
-    /**
-     * @param ConnectionOptions|null $options
-     * @return \Humus\Amqp\Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): \Humus\Amqp\Connection
+    public function createConnection(?ConnectionOptions $options = null): \Humus\Amqp\Connection
     {
         return new LazySocketConnection($options);
     }

--- a/tests/PhpAmqpLib/PlainProducerTest.php
+++ b/tests/PhpAmqpLib/PlainProducerTest.php
@@ -25,10 +25,6 @@ namespace HumusTest\Amqp\PhpAmqpLib;
 use HumusTest\Amqp\AbstractPlainProducerTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class PlainProducerTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class PlainProducerTest extends AbstractPlainProducerTest
 {
     use CreateConnectionTrait;

--- a/tests/PhpAmqpLib/QueueTest.php
+++ b/tests/PhpAmqpLib/QueueTest.php
@@ -26,10 +26,6 @@ use Humus\Amqp\Exception\QueueException;
 use HumusTest\Amqp\AbstractQueueTest;
 use HumusTest\Amqp\PhpAmqpLib\Helper\CreateConnectionTrait;
 
-/**
- * Class QueueTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class QueueTest extends AbstractQueueTest
 {
     use CreateConnectionTrait;
@@ -37,7 +33,7 @@ final class QueueTest extends AbstractQueueTest
     /**
      * @test
      */
-    public function it_consumes_without_callback()
+    public function it_consumes_without_callback(): void
     {
         $this->expectException(QueueException::class);
 

--- a/tests/PhpAmqpLib/SocketConnectionTest.php
+++ b/tests/PhpAmqpLib/SocketConnectionTest.php
@@ -26,16 +26,12 @@ use Humus\Amqp\ConnectionOptions;
 use Humus\Amqp\Driver\PhpAmqpLib\SocketConnection;
 use HumusTest\Amqp\AbstractConnectionTest;
 
-/**
- * Class SocketConnectionTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class SocketConnectionTest extends AbstractConnectionTest
 {
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_credentials()
+    public function it_throws_exception_with_invalid_credentials(): void
     {
         $this->expectException(\Exception::class);
 
@@ -45,7 +41,7 @@ final class SocketConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_connects_with_valid_credentials()
+    public function it_connects_with_valid_credentials(): void
     {
         $connection = $this->createConnection();
 
@@ -55,18 +51,14 @@ final class SocketConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_returns_internal_connection()
+    public function it_returns_internal_connection(): void
     {
         $connection = $this->createConnection();
 
         $this->assertInstanceOf(\PhpAmqpLib\Connection\AMQPSocketConnection::class, $connection->getResource());
     }
 
-    /**
-     * @param ConnectionOptions|null $options
-     * @return \Humus\Amqp\Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): \Humus\Amqp\Connection
+    public function createConnection(?ConnectionOptions $options = null): \Humus\Amqp\Connection
     {
         if (null === $options) {
             $options = new ConnectionOptions();

--- a/tests/PhpAmqpLib/SslConnectionTest.php
+++ b/tests/PhpAmqpLib/SslConnectionTest.php
@@ -44,7 +44,7 @@ final class SslConnectionTest extends AbstractConnectionTest
 
         $options->setVhost('/humus-amqp-test');
         $options->setPort(5671);
-        $options->setCACert(__DIR__ . '/../../provision/test_certs/cacert.pem');
+        $options->setCaCert(__DIR__ . '/../../provision/test_certs/cacert.pem');
         $options->setCert(__DIR__ . '/../../provision/test_certs/cert.pem');
         $options->setKey(__DIR__ . '/../../provision/test_certs/key.pem');
         $options->setVerify(false);
@@ -61,7 +61,7 @@ final class SslConnectionTest extends AbstractConnectionTest
 
         $options->setVhost('/humus-amqp-test');
         $options->setPort(5671);
-        $options->setCACert(__DIR__ . '/../../provision/test_certs/cacert.pem');
+        $options->setCaCert(__DIR__ . '/../../provision/test_certs/cacert.pem');
         $options->setVerify(false);
 
         $connection = new SslConnection($options);
@@ -148,7 +148,7 @@ final class SslConnectionTest extends AbstractConnectionTest
 
         $options->setVhost('/humus-amqp-test');
         $options->setPort(5671);
-        $options->setCACert(__DIR__ . '/../../provision/test_certs/cacert.pem');
+        $options->setCaCert(__DIR__ . '/../../provision/test_certs/cacert.pem');
         $options->setCert(__DIR__ . '/../../provision/test_certs/cert.pem');
         $options->setKey(__DIR__ . '/../../provision/test_certs/key.pem');
         $options->setVerify(false);

--- a/tests/PhpAmqpLib/SslConnectionTest.php
+++ b/tests/PhpAmqpLib/SslConnectionTest.php
@@ -29,8 +29,6 @@ use Humus\Amqp\Exception\InvalidArgumentException;
 use HumusTest\Amqp\AbstractConnectionTest;
 
 /**
- * Class SslConnectionTest
- * @package HumusTest\Amqp\PhpAmqpLib
  * @group ssl
  */
 final class SslConnectionTest extends AbstractConnectionTest
@@ -38,7 +36,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_credentials()
+    public function it_throws_exception_with_invalid_credentials(): void
     {
         $this->expectException(\Exception::class);
 
@@ -57,7 +55,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_connects_with_only_cacert()
+    public function it_connects_with_only_cacert(): void
     {
         $options = new ConnectionOptions();
 
@@ -74,7 +72,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_connects_with_valid_credentials()
+    public function it_connects_with_valid_credentials(): void
     {
         $connection = $this->createConnection();
 
@@ -84,7 +82,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_returns_internal_connection()
+    public function it_returns_internal_connection(): void
     {
         $connection = $this->createConnection();
 
@@ -94,7 +92,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_reconnects()
+    public function it_reconnects(): void
     {
         $connection = $this->createConnection();
         $this->assertTrue($connection->isConnected());
@@ -106,7 +104,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_throws_exception_on_connect()
+    public function it_throws_exception_on_connect(): void
     {
         $this->expectException(BadMethodCallException::class);
 
@@ -117,7 +115,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_throws_exception_on_disconnect()
+    public function it_throws_exception_on_disconnect(): void
     {
         $this->expectException(BadMethodCallException::class);
 
@@ -128,7 +126,7 @@ final class SslConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_throws_if_cacert_not_set_but_verify_is_set_to_true()
+    public function it_throws_if_cacert_not_set_but_verify_is_set_to_true(): void
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('CA cert not set, so it can\'t be verified.');
@@ -142,11 +140,7 @@ final class SslConnectionTest extends AbstractConnectionTest
         new SslConnection($options);
     }
 
-    /**
-     * @param ConnectionOptions|null $options
-     * @return \Humus\Amqp\Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): \Humus\Amqp\Connection
+    public function createConnection(?ConnectionOptions $options = null): \Humus\Amqp\Connection
     {
         if (null === $options) {
             $options = new ConnectionOptions();

--- a/tests/PhpAmqpLib/StreamConnectionTest.php
+++ b/tests/PhpAmqpLib/StreamConnectionTest.php
@@ -28,16 +28,12 @@ use Humus\Amqp\Driver\PhpAmqpLib\StreamConnection;
 use Humus\Amqp\Exception\BadMethodCallException;
 use HumusTest\Amqp\AbstractConnectionTest;
 
-/**
- * Class StreamConnectionTest
- * @package HumusTest\Amqp\PhpAmqpLib
- */
 final class StreamConnectionTest extends AbstractConnectionTest
 {
     /**
      * @test
      */
-    public function it_throws_exception_with_invalid_credentials()
+    public function it_throws_exception_with_invalid_credentials(): void
     {
         $this->expectException(\Exception::class);
 
@@ -47,7 +43,7 @@ final class StreamConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_connects_with_valid_credentials()
+    public function it_connects_with_valid_credentials(): void
     {
         $connection = $this->createConnection();
 
@@ -57,7 +53,7 @@ final class StreamConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_returns_internal_connection()
+    public function it_returns_internal_connection(): void
     {
         $connection = $this->createConnection();
 
@@ -68,7 +64,7 @@ final class StreamConnectionTest extends AbstractConnectionTest
      * @test
      * @doesNotPerformAssertions
      */
-    public function it_reconnects()
+    public function it_reconnects(): void
     {
         $connection = $this->createConnection();
         $connection->reconnect();
@@ -77,7 +73,7 @@ final class StreamConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_throws_exception_on_connect()
+    public function it_throws_exception_on_connect(): void
     {
         $this->expectException(BadMethodCallException::class);
 
@@ -88,7 +84,7 @@ final class StreamConnectionTest extends AbstractConnectionTest
     /**
      * @test
      */
-    public function it_throws_exception_on_disconnect()
+    public function it_throws_exception_on_disconnect(): void
     {
         $this->expectException(BadMethodCallException::class);
 
@@ -96,11 +92,7 @@ final class StreamConnectionTest extends AbstractConnectionTest
         $connection->disconnect();
     }
 
-    /**
-     * @param ConnectionOptions|null $options
-     * @return Connection
-     */
-    public function createConnection(ConnectionOptions $options = null): Connection
+    public function createConnection(?ConnectionOptions $options = null): Connection
     {
         if (null === $options) {
             $options = new ConnectionOptions();

--- a/tests/TestAsset/ArrayLogger.php
+++ b/tests/TestAsset/ArrayLogger.php
@@ -24,66 +24,56 @@ namespace HumusTest\Amqp\TestAsset;
 
 use Psr\Log\LoggerInterface;
 
-/**
- * Class ArrayLogger
- * @package HumusTest\Amqp\TestAsset
- */
 class ArrayLogger implements LoggerInterface
 {
-    /**
-     * @var array
-     */
-    private $loggerResult = [];
+    private array $loggerResult = [];
 
-    /**
-     * @return array
-     */
-    public function loggerResult()
+    public function loggerResult(): array
     {
         return $this->loggerResult;
     }
 
-    public function emergency($message, array $context = [])
+    public function emergency($message, array $context = []): void
     {
         $this->log('emergency', $message, $context);
     }
 
-    public function alert($message, array $context = [])
+    public function alert($message, array $context = []): void
     {
         $this->log('alert', $message, $context);
     }
 
-    public function critical($message, array $context = [])
+    public function critical($message, array $context = []): void
     {
         $this->log('critical', $message, $context);
     }
 
-    public function error($message, array $context = [])
+    public function error($message, array $context = []): void
     {
         $this->log('error', $message, $context);
     }
 
-    public function warning($message, array $context = [])
+    public function warning($message, array $context = []): void
     {
         $this->log('warning', $message, $context);
     }
 
-    public function notice($message, array $context = [])
+    public function notice($message, array $context = []): void
     {
         $this->log('notice', $message, $context);
     }
 
-    public function info($message, array $context = [])
+    public function info($message, array $context = []): void
     {
         $this->log('info', $message, $context);
     }
 
-    public function debug($message, array $context = [])
+    public function debug($message, array $context = []): void
     {
         $this->log('debug', $message, $context);
     }
 
-    public function log($level, $message, array $context = [])
+    public function log($level, $message, array $context = []): void
     {
         $this->loggerResult[] = [
             'level' => $level,


### PR DESCRIPTION
BC BREAK
- Instead of returning FALSE from the queue, when no message was found, it returns NULL instead.
- `ConnectionOptions` class has getters renamed (no get-prefix)